### PR TITLE
Launch readiness: QA blockers and minors from 2026-07-08 review

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,24 @@
+name: Bug report
+description: Something broke or behaved contrary to the docs
+labels: [bug]
+body:
+  - type: textarea
+    id: what
+    attributes:
+      label: What happened
+      description: The command you ran and its full output (`--json` output welcome).
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What you expected
+    validations:
+      required: true
+  - type: input
+    id: versions
+    attributes:
+      label: Versions
+      description: Output of `skill-set --version`, plus Node version and OS.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/hcjmartin/skill-set/security/advisories/new
+    about: Report privately — never in a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,18 @@
+name: Feature request
+description: Propose a change to the CLI or the format
+labels: [enhancement]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What can't you do today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed behaviour
+      description: For format changes, note the spec section it touches.
+    validations:
+      required: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,4 @@
 .flocker
-# local-only until the public flip
-CHANGELOG.md
 node_modules/
 dist/
 coverage/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ pnpm install --frozen-lockfile
 - `pnpm -w run check` must pass: it runs build, typecheck, lint, and the vitest suites in order. Run a single package's tests with `pnpm --filter @skill-set/cli test`.
 - Add a changeset (`pnpm changeset`) for any change visible to users of the published package.
 - New behaviour needs tests in the existing style: table-driven where possible, hermetic (the upstream `skills` CLI is faked, never hit over the network in PR CI).
-- Comments are one-liners, and only where the code alone would mislead; the reasoning behind non-obvious choices goes in the root `CHANGELOG.md`.
+- Comments are one-liners, and only where the code alone would mislead; the reasoning behind non-obvious choices goes in the change's changeset entry (it becomes the published CHANGELOG).
 
 ## Dependency rules
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A **skill-set** is a single JSON manifest — `<name>.skill-set.json` — listin
 
 This repo ships the open format (a normative convention plus JSON Schemas), reference CLI [`@skill-set/cli`](https://www.npmjs.com/package/@skill-set/cli) (command: `skill-set`), and an optional content-hash lock that makes a set's skill contents byte-exactly verifiable on another machine.
 
-The CLI wraps the [`skills`](https://github.com/vercel-labs/skills) CLI (rolling pinned version) for resolving and installing individual skills.
+The CLI wraps the [`skills`](https://github.com/vercel-labs/skills) CLI (pinned to an exact version, bumped deliberately) for resolving and installing individual skills.
 
 **Status: pre-release.** The format is in draft and the CLI is pre-1.0; both may still change.
 
@@ -61,7 +61,7 @@ In CI, frozen is already the default whenever a lock exists.
 
 The normative convention — manifest fields, validation rules, sharing semantics, the lock format, and the content-hash recipe lives at [spec/draft/README.md](spec/draft/README.md), written so a set can be authored, resolved, and verified without this CLI. 
 
-Documentation will live at [skill-set.md](https://skill-set.md) once the site is up.
+Documentation lives at [skill-set.md](https://skill-set.md).
 
 ## Naming
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,6 +12,8 @@ You should receive an acknowledgement within a few days. Please include reproduc
 
 This policy covers the `@skill-set/cli` package and the skill-set format specification in this repository. The CLI shells out to the pinned upstream `skills` CLI: a vulnerability in that tool itself belongs upstream at [vercel-labs/skills](https://github.com/vercel-labs/skills); a vulnerability in how this CLI invokes it, or in what it does with the results, belongs here.
 
+Spawned children (the upstream CLI via `npx`) deliberately inherit the full parent environment: they run the user's own npm toolchain, which needs PATH managers, proxy settings, and registry auth to function. Treat anything in your environment as visible to the pinned upstream tool.
+
 ## Supported versions
 
 Pre-1.0, only the latest published release receives fixes.

--- a/packages/cli/LICENSE
+++ b/packages/cli/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Harry Martin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,3 +1,11 @@
 import { run } from './run.ts'
 
+// A consumer closing the pipe early (`skill-set … --json | head`) is a normal exit, not a crash.
+const exitOnEpipe = (error: NodeJS.ErrnoException) => {
+  if (error.code === 'EPIPE') process.exit(0)
+  throw error
+}
+process.stdout.on('error', exitOnEpipe)
+process.stderr.on('error', exitOnEpipe)
+
 process.exitCode = await run(process.argv.slice(2))

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -15,6 +15,7 @@ export const ADD_USAGE = 'skill-set add <url|path> [--hash sha256:<hex>]'
 /** Spec §3 fetch bounds: at most five redirects, at most 1 MiB of manifest. */
 const MAX_REDIRECTS = 5
 const MAX_BYTES = 1024 * 1024
+const FETCH_TIMEOUT_MS = 30_000
 
 const HEX64 = /^[a-f0-9]{64}$/
 
@@ -509,8 +510,11 @@ export async function fetchManifest(url: string): Promise<Result<string>> {
   for (let i = 0; i <= MAX_REDIRECTS; i++) {
     let response: Response
     try {
-      response = await fetch(current, { redirect: 'manual' })
+      response = await fetch(current, { redirect: 'manual', signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) })
     } catch (cause) {
+      if (cause instanceof Error && cause.name === 'TimeoutError') {
+        return fetchFail(url, `no response within ${FETCH_TIMEOUT_MS / 1000}s`, 'Check the URL and your network, then retry.')
+      }
       return fetchFail(url, (cause as Error).message, 'Check the URL and your network, then retry.')
     }
     if (response.status >= 300 && response.status < 400) {
@@ -525,14 +529,27 @@ export async function fetchManifest(url: string): Promise<Result<string>> {
       continue
     }
     if (!response.ok) return fetchFail(url, `GET returned ${response.status}`)
-    // Manifests are small; the cap guards against pointing `add` at the wrong thing (spec §3).
-    const text = await response.text()
-    if (Buffer.byteLength(text, 'utf8') > MAX_BYTES) {
-      return fetchFail(url, `response exceeds the ${MAX_BYTES / 1024 / 1024} MiB manifest cap`)
-    }
-    return { ok: true, data: text }
+    return readCappedBody(url, response)
   }
   return fetchFail(url, `more than ${MAX_REDIRECTS} redirects`)
+}
+
+/**
+ * Manifests are small; the cap guards against pointing `add` at the wrong thing (spec §3).
+ * Enforced while streaming, so an oversized or unbounded body never buffers past the cap.
+ */
+async function readCappedBody(url: string, response: Response): Promise<Result<string>> {
+  const overCap = `response exceeds the ${MAX_BYTES / 1024 / 1024} MiB manifest cap`
+  if (Number(response.headers.get('content-length')) > MAX_BYTES) return fetchFail(url, overCap)
+  if (response.body === null) return { ok: true, data: '' }
+  const chunks: Uint8Array[] = []
+  let received = 0
+  for await (const chunk of response.body) {
+    received += chunk.length
+    if (received > MAX_BYTES) return fetchFail(url, overCap)
+    chunks.push(chunk)
+  }
+  return { ok: true, data: Buffer.concat(chunks).toString('utf8') }
 }
 
 function fetchFail(url: string, reason: string, hint?: string): Result<never> {

--- a/packages/cli/src/hash.ts
+++ b/packages/cli/src/hash.ts
@@ -44,7 +44,7 @@ export function specFolderHash(dir: string): string {
  * interoperate with skills-lock.json. Locale-sensitive by upstream design; not the spec hash.
  * Matches upstream lock entries only for disk-based installs, computed over the SOURCE folder
  * (the installer strips metadata.json from the copy). GitHub blob-path installs record a
- * server-side snapshot hash instead, which no local bytes reproduce (see CHANGELOG).
+ * server-side snapshot hash instead, which no local bytes reproduce (see test/compat.test.ts).
  */
 export function compatFolderHash(dir: string): string {
   const files = collectFiles(dir, dir)

--- a/packages/cli/src/resolver.ts
+++ b/packages/cli/src/resolver.ts
@@ -7,8 +7,8 @@ import { parseSkillsLock } from './lock.ts'
 import { NAME_PATTERN } from './manifest.ts'
 import { runCommand, type SpawnOptions, type SpawnOutcome } from './spawn.ts'
 
-/** Upstream pin, minor-level: patch releases float in, minor/major bumps are deliberate. */
-export const SKILLS_PIN = '1.5'
+/** Upstream pin, exact: every bump is deliberate (the weekly compat job watches upstream drift). */
+export const SKILLS_PIN = '1.5.14'
 
 /** Where resolved skills land, relative to the project root (spec §4; upstream UNIVERSAL_SKILLS_DIR). */
 export const SKILLS_DIR = '.agents/skills'
@@ -64,7 +64,7 @@ export function buildAddInvocation(locator: string, opts?: { global?: boolean })
   args.push('--yes')
   if (opts?.global === true) args.push('--global')
   // Suppresses upstream telemetry events via its own opt-out; its audit fetch
-  // (add-skill.vercel.sh) is separate and not opt-out-able (see CHANGELOG).
+  // (add-skill.vercel.sh) is separate and not opt-out-able.
   const env: Record<string, string> = {}
   if (buildConfig.suppressUpstreamTelemetry) env.DISABLE_TELEMETRY = '1'
   return { command: 'npx', args, env }
@@ -254,8 +254,8 @@ export async function resolveMember(
   }
 
   // The upstream lock's computedHash is opaque here: for GitHub blob installs it is a
-  // server-side snapshot hash no local bytes can reproduce (see CHANGELOG). Our set-lock
-  // records the spec §6 hash of the installed folder instead.
+  // server-side snapshot hash no local bytes can reproduce (verified empirically; see
+  // test/compat.test.ts). Our set-lock records the spec §6 hash of the installed folder instead.
   return {
     ok: true,
     data: {

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -80,7 +80,8 @@ export async function run(argv: readonly string[], overrides: RunOverrides = {})
   const ours = sentinel === -1 ? [...argv] : [...argv.slice(0, sentinel)]
   const passthrough = sentinel === -1 ? [] : [...argv.slice(sentinel + 1)]
 
-  // Meta-flags are intercepted before any dispatch — `<verb> --help` must never execute (see CHANGELOG).
+  // Meta-flags are intercepted before any dispatch — upstream runs `update` even when passed
+  // `--help` (verified foot-gun); that bug class must be structurally impossible here.
   if (ours.length === 0 || ours.includes('--help') || ours.includes('-h')) {
     stdout.write(HELP)
     return 0

--- a/packages/cli/src/spawn.ts
+++ b/packages/cli/src/spawn.ts
@@ -27,6 +27,8 @@ export async function runCommand(
     nodeOptions: {
       stdio: opts?.capture ? 'pipe' : 'inherit',
       cwd: opts?.cwd,
+      // Full env inherited deliberately: children run the user's npm toolchain, which needs
+      // PATH managers, proxies, and registry auth (SECURITY.md "Scope").
       env: opts?.env === undefined ? process.env : { ...process.env, ...opts.env },
     },
   })

--- a/packages/cli/test/cli-commands.test.ts
+++ b/packages/cli/test/cli-commands.test.ts
@@ -155,8 +155,8 @@ describe('authoring round-trip: init → install → lock → build → verify �
     expect(existsSync(join(cwd, SKILLS_DIR, 'alpha'))).toBe(true)
     expect(existsSync(join(cwd, SKILLS_DIR, 'beta-repo'))).toBe(true)
     // Named member forwards --skill; both spawns are the pinned invocation.
-    expect(fake.calls[0]).toEqual(['npx', '-y', 'skills@1.5', 'add', 'hcjmartin/alpha-repo', '--skill', 'alpha', '--yes'])
-    expect(fake.calls[1]).toEqual(['npx', '-y', 'skills@1.5', 'add', 'hcjmartin/beta-repo', '--yes'])
+    expect(fake.calls[0]).toEqual(['npx', '-y', 'skills@1.5.14', 'add', 'hcjmartin/alpha-repo', '--skill', 'alpha', '--yes'])
+    expect(fake.calls[1]).toEqual(['npx', '-y', 'skills@1.5.14', 'add', 'hcjmartin/beta-repo', '--yes'])
   })
 
   it('lock records the installed content', async () => {
@@ -216,7 +216,7 @@ describe('authoring round-trip: init → install → lock → build → verify �
     const before = parseSetLock(readFileSync(join(setDir, 'my-tools.skill-set.lock.json'), 'utf8'))
     const { code } = await cli(cwd, fake, ['update', 'my-tools'])
     expect(code).toBe(0)
-    expect(fake.calls.at(-1)).toEqual(['npx', '-y', 'skills@1.5', 'update', 'alpha', 'beta-repo', '-p', '--yes'])
+    expect(fake.calls.at(-1)).toEqual(['npx', '-y', 'skills@1.5.14', 'update', 'alpha', 'beta-repo', '-p', '--yes'])
     const after = parseSetLock(readFileSync(join(setDir, 'my-tools.skill-set.lock.json'), 'utf8'))
     expect(before.ok && after.ok && before.data.setHash !== after.data.setHash).toBe(true)
     // The re-lock accepted the updated bytes, so frozen verify is green again.
@@ -228,7 +228,7 @@ describe('authoring round-trip: init → install → lock → build → verify �
     const otherFake = fakeSkills(other)
     await cli(other, otherFake, ['init', 'p', 'hcjmartin/x-repo@x'])
     await cli(other, otherFake, ['install', 'p', '--', '--verbose'])
-    expect(otherFake.calls[0]).toEqual(['npx', '-y', 'skills@1.5', 'add', 'hcjmartin/x-repo', '--skill', 'x', '--yes', '--verbose'])
+    expect(otherFake.calls[0]).toEqual(['npx', '-y', 'skills@1.5.14', 'add', 'hcjmartin/x-repo', '--skill', 'x', '--yes', '--verbose'])
   })
 
   it('our own flags after -- forward to upstream instead of switching our modes', async () => {
@@ -242,7 +242,7 @@ describe('authoring round-trip: init → install → lock → build → verify �
     expect(out).not.toContain('Usage: skill-set')
     expect(out.trimStart().startsWith('{')).toBe(false)
     expect(otherFake.calls[0]).toEqual([
-      'npx', '-y', 'skills@1.5', 'add', 'hcjmartin/y-repo', '--skill', 'y', '--yes', '--json', '--help',
+      'npx', '-y', 'skills@1.5.14', 'add', 'hcjmartin/y-repo', '--skill', 'y', '--yes', '--json', '--help',
     ])
   })
 })
@@ -300,7 +300,7 @@ describe('remove', () => {
     expect(removed.out).toContain('kept alpha: shared with another set')
     // --yes answered the second prompt too: only the unshared skill went to the upstream remove.
     const removeCall = fake.calls.slice(spawnsBefore).find((c) => c[3] === 'remove')
-    expect(removeCall).toEqual(['npx', '-y', 'skills@1.5', 'remove', 'beta', '--yes'])
+    expect(removeCall).toEqual(['npx', '-y', 'skills@1.5.14', 'remove', 'beta', '--yes'])
     const index = JSON.parse(readFileSync(join(cwd, SETS_DIR, INDEX_FILENAME), 'utf8')) as { sets: Record<string, unknown> }
     expect(Object.keys(index.sets)).toEqual(['two'])
   })
@@ -316,7 +316,7 @@ describe('remove', () => {
     expect(out).toContain(`Skill-set "kit" (from ${url}) was successfully removed`)
     expect(existsSync(join(cwd, SKILLS_DIR, 'gamma'))).toBe(false)
     const removeCall = fake.calls.slice(spawnsBefore).find((c) => c[3] === 'remove')
-    expect(removeCall).toEqual(['npx', '-y', 'skills@1.5', 'remove', 'gamma', '--yes'])
+    expect(removeCall).toEqual(['npx', '-y', 'skills@1.5.14', 'remove', 'gamma', '--yes'])
   })
 
   it('scripted yes/no removes the set but leaves its skills untouched', async () => {
@@ -1214,7 +1214,7 @@ describe('build --lock and delegated-spawn provenance', () => {
     }
     const { code, out, err } = await cli(cwd, grumpyCheck, ['verify', 'w'])
     expect(code).toBe(0)
-    expect(out).toContain('running: npx -y skills@1.5 check')
+    expect(out).toContain('running: npx -y skills@1.5.14 check')
     expect(err).toContain('upstream "skills check" exited with code 3')
   })
 })
@@ -1226,7 +1226,7 @@ describe('--dry-run', () => {
     await cli(cwd, fake, ['init', 'd', 'hcjmartin/alpha-repo@alpha'])
     const { code, out } = await cli(cwd, fake, ['install', 'd', '--dry-run'])
     expect(code).toBe(0)
-    expect(out).toContain('would run: npx -y skills@1.5 add hcjmartin/alpha-repo --skill alpha --yes')
+    expect(out).toContain('would run: npx -y skills@1.5.14 add hcjmartin/alpha-repo --skill alpha --yes')
     expect(out).toContain('dry run — no files changed, no skills installed')
     expect(fake.calls).toHaveLength(0)
     expect(existsSync(join(cwd, SKILLS_DIR, 'alpha'))).toBe(false)
@@ -1264,7 +1264,7 @@ describe('--dry-run', () => {
     const spawnsBefore = fake.calls.length
     const { code, out } = await cli(cwd, fake, ['update', 'd', '--dry-run'])
     expect(code).toBe(0)
-    expect(out).toContain('would run: npx -y skills@1.5 update alpha -p --yes')
+    expect(out).toContain('would run: npx -y skills@1.5.14 update alpha -p --yes')
     expect(fake.calls.length).toBe(spawnsBefore)
   })
 })

--- a/packages/cli/test/fetch-manifest.test.ts
+++ b/packages/cli/test/fetch-manifest.test.ts
@@ -76,6 +76,35 @@ describe('fetchManifest', () => {
     if (!result.ok) expect(result.error.message).toContain('MiB manifest cap')
   })
 
+  it('refuses an over-cap declared Content-Length before reading the body', async () => {
+    stub(() => new Response('tiny', { headers: { 'content-length': String(2 * 1024 * 1024) } }))
+    const result = await fetchManifest('https://example.test/a')
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error.message).toContain('MiB manifest cap')
+  })
+
+  it('reports a hung host as a timeout with the deadline, not a raw abort', async () => {
+    const timeout = new Error('The operation was aborted due to timeout')
+    timeout.name = 'TimeoutError'
+    vi.stubGlobal('fetch', vi.fn(async () => Promise.reject(timeout)))
+    const result = await fetchManifest('https://example.test/a')
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error.message).toContain('no response within 30s')
+  })
+
+  it('passes an abort deadline to every fetch', async () => {
+    let signal: unknown
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (_url: unknown, init?: RequestInit) => {
+        signal = init?.signal
+        return new Response('{"name":"x"}')
+      }),
+    )
+    await fetchManifest('https://example.test/a')
+    expect(signal).toBeInstanceOf(AbortSignal)
+  })
+
   it('fails a redirect that crosses to an unrecognised host, naming only the host', async () => {
     stub(() => redirect('https://evil.test/payload?MARKER-REDIRECT-INJ'))
     const result = await fetchManifest('https://skill-set.md/x.skill-set.json')

--- a/packages/cli/test/run.test.ts
+++ b/packages/cli/test/run.test.ts
@@ -47,7 +47,7 @@ describe('run — dispatch and meta-flags', () => {
     const { code, out } = await cli(['--version'])
     expect(code).toBe(0)
     expect(out).toContain(`skill-set/${VERSION}`)
-    expect(out).toContain('skills@1.5')
+    expect(out).toContain('skills@1.5.14')
   })
 
   it('intercepts --version after a verb before any dispatch', async () => {

--- a/packages/site/src/pages/cli.md
+++ b/packages/site/src/pages/cli.md
@@ -9,10 +9,10 @@ lede: The CLI ships as @skill-set/cli with a single bin, skill-set. Run it witho
 npx @skill-set/cli <command> [args] [flags] [-- <args for the skills CLI>]
 ```
 
-Resolution and installation of individual skills are delegated to the upstream [skills CLI](https://skills.sh), pinned to `skills@1.5`. `skill-set --version` prints both versions:
+Resolution and installation of individual skills are delegated to the upstream [skills CLI](https://skills.sh), pinned to `skills@1.5.14`. `skill-set --version` prints both versions:
 
 ```
-skill-set/<version> (wraps skills@1.5, pinned)
+skill-set/<version> (wraps skills@1.5.14, pinned)
 ```
 
 ## Commands
@@ -53,7 +53,7 @@ Hosts other than recognised skill-set providers prompt for confirmation before a
 skill-set install <set>
 ```
 
-Before anything installs, every set in the project is checked for members pinned to conflicting refs — a conflict aborts with exit code 4 (see the [FAQ](/faq/#what-happens-when-two-sets-want-the-same-skill)). Members whose locked content is already on disk byte-for-byte are skipped; the rest resolve one at a time through `npx skills@1.5 add <locator>`. The summary reports installed, skipped, and failed counts, and any member failure makes the whole command fail after attempting the rest.
+Before anything installs, every set in the project is checked for members pinned to conflicting refs — a conflict aborts with exit code 4 (see the [FAQ](/faq/#what-happens-when-two-sets-want-the-same-skill)). Members whose locked content is already on disk byte-for-byte are skipped; the rest resolve one at a time through `npx skills@1.5.14 add <locator>`. The summary reports installed, skipped, and failed counts, and any member failure makes the whole command fail after attempting the rest.
 
 ### build
 
@@ -100,7 +100,7 @@ In CI, frozen is the default whenever a set-lock exists; `--no-frozen` opts out.
 skill-set update <set>
 ```
 
-Updates every member through `npx skills@1.5 update <skills...> -p --yes`, then re-locks the set if a lock existed and regenerates the derived files. All members must be installed before anything updates.
+Updates every member through `npx skills@1.5.14 update <skills...> -p --yes`, then re-locks the set if a lock existed and regenerates the derived files. All members must be installed before anything updates.
 
 ### remove
 

--- a/packages/site/src/pages/faq.md
+++ b/packages/site/src/pages/faq.md
@@ -55,13 +55,13 @@ Trust is layered, and each layer has a defined job:
 3. **When adding a shared set (optional, recommended for third-party sets)**: if the share URL carries a hash fragment (`…skill-set.json#sha256=<hash>`) or you pass `--hash`, and/or the author published their lock beside the manifest, `add` verifies the installed content against it. If an already-installed local copy does not match, `add` re-fetches that member in a clean staging project and checks the published content without changing your installed copy. Content that does not match the provided hash or the published lock is not kept — the set files are removed and the command fails.
 4. **After that, over time**: your committed lock plus `verify --frozen` (the CI default) catches any later drift, byte-exactly, member by member.
 
-Skill resolution itself is delegated to the pinned `skills@1.5` CLI with prompts suppressed — the trust decisions all happen in the layers above, not in the delegated fetch.
+Skill resolution itself is delegated to the pinned `skills@1.5.14` CLI with prompts suppressed — the trust decisions all happen in the layers above, not in the delegated fetch.
 
 One boundary to be clear about: hashes prove **integrity**, not **safety**. A verified set is exactly what its author locked — which says nothing about whether that content is a good idea to run. Review third-party sets (or use a skill scanner) before installing them, the same way you would vet any dependency.
 
 ## How does skill-set relate to the skills CLI?
 
-It is a companion, not a fork. The skills CLI resolves and installs individual skills; skill-set adds the set layer — named manifests, sharing by URL, locks, and verification. Every member resolution shells out to the pinned upstream (`npx skills@1.5`), and arguments after `--` pass through to it verbatim. Locators in a manifest are whatever `npx skills add` accepts.
+It is a companion, not a fork. The skills CLI resolves and installs individual skills; skill-set adds the set layer — named manifests, sharing by URL, locks, and verification. Every member resolution shells out to the pinned upstream (`npx skills@1.5.14`), and arguments after `--` pass through to it verbatim. Locators in a manifest are whatever `npx skills add` accepts.
 
 ## Is this the `skillset`, `skillsets`, or `skills-set` package on npm?
 

--- a/packages/site/src/pages/index.astro
+++ b/packages/site/src/pages/index.astro
@@ -85,7 +85,7 @@ const manifest = `{
     </li>
     <li>
       <strong>Resolution is delegated.</strong> The CLI shells out to the pinned upstream
-      <code>npx skills@1.5</code> to fetch and install members; it adds sets, locks, and verification on top. Arguments
+      <code>npx skills@1.5.14</code> to fetch and install members; it adds sets, locks, and verification on top. Arguments
       after <code>--</code> pass through to the skills CLI verbatim.
     </li>
     <li>


### PR DESCRIPTION
Prep for public release.

- **LICENSE** copied into `packages/cli/` so the published tarball ships license text
- **Changelog**: `CHANGELOG.md` un-ignored so the changesets-generated `packages/cli/CHANGELOG.md` can be tracked
- **Fetch hardening**: 30s timeout, Content-Length pre-check, 1 MiB cap enforced 
- **Exact upstream pin** `skills@1.5.14`
- **EPIPE** swallowed at the entry point
- **Docs**: copy update for accuracy
- **Spawn env** documented as deliberately inherited (SECURITY.md)
- `.gitattributes` (LF normalization protects byte-exact hash tests), issue templates with blank issues disabled, generated site schema copies untracked