### PR TITLE
Hash/resolve edge tests, coverage floor, and example-ref fixes

### DIFF
--- a/.changeset/cold-hoops-ask.md
+++ b/.changeset/cold-hoops-ask.md
@@ -1,0 +1,5 @@
+---
+"@skill-set/cli": patch
+---
+
+Correct the example locator in the `init` usage hint (vercel-labs/skills@find-skills).

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -23,7 +23,7 @@ export async function cmdInit(args: string[], ctx: CommandContext): Promise<Comm
     // The schema requires at least one member, so an empty scaffold would be invalid on arrival.
     return usageError(
       'init needs at least one member locator — a skill-set cannot be empty',
-      `${INIT_USAGE}, e.g. skill-set init ${name} vercel-labs/agent-skills@find-skills`,
+      `${INIT_USAGE}, e.g. skill-set init ${name} vercel-labs/skills@find-skills`,
     )
   }
 

--- a/packages/cli/test/hash.test.ts
+++ b/packages/cli/test/hash.test.ts
@@ -15,7 +15,7 @@ const SET_HASH = 'eec2eccf9a66a06dda6bd61db3414acca5d66d8edb0de8fe1dc63d2ff808f5
 
 const dirs: string[] = []
 
-function tmpFolder(files: Record<string, string>): string {
+function tmpFolder(files: Record<string, string | Uint8Array>): string {
   const dir = mkdtempSync(join(tmpdir(), 'skill-set-hash-'))
   dirs.push(dir)
   for (const [rel, content] of Object.entries(files)) {
@@ -91,6 +91,60 @@ describe('specFolderHash', () => {
     expect(specFolderHash(b)).toBe(digest)
   })
 
+  it('hashes a realistic skill folder (SKILL.md, metadata.json, nested files)', () => {
+    const files: Record<string, string> = {
+      'SKILL.md': '---\nname: probe-skill\ndescription: Fixture skill.\n---\n\n# Probe\n\nBody.\n',
+      'metadata.json': '{ "category": "testing" }\n',
+      'scripts/helper.sh': '#!/bin/sh\necho probe\n',
+      'reference/notes.md': 'Some notes.\n',
+    }
+    const dir = tmpFolder(files)
+    // Frame the same files independently (spec §6): UTF-8-byte path sort, NUL delimiters.
+    const ordered = Object.keys(files).sort((a, b) =>
+      Buffer.compare(Buffer.from(a, 'utf8'), Buffer.from(b, 'utf8')),
+    )
+    const expected = createHash('sha256')
+    for (const rel of ordered) {
+      expected.update(rel, 'utf8')
+      expected.update(Buffer.from([0]))
+      expected.update(files[rel]!, 'utf8')
+      expected.update(Buffer.from([0]))
+    }
+    expect(specFolderHash(dir)).toBe(expected.digest('hex'))
+    expect(specFolderHash(dir)).toBe(specFolderHash(dir)) // stable across runs
+  })
+
+  it('hashes binary content, including embedded NUL and high bytes, framed by NUL', () => {
+    // The framing NUL is a delimiter, not an escape — content bytes (0x00 included) go in raw.
+    const bytes = Uint8Array.from([0x00, 0x01, 0xff, 0x80, 0x0a, 0x00])
+    const dir = tmpFolder({ 'blob.bin': bytes })
+    const expected = createHash('sha256')
+    expected.update('blob.bin', 'utf8')
+    expected.update(Buffer.from([0]))
+    expected.update(Buffer.from(bytes))
+    expected.update(Buffer.from([0]))
+    expect(specFolderHash(dir)).toBe(expected.digest('hex'))
+  })
+
+  it('hashes files nested deeper than one level, joining segments with "/"', () => {
+    const dir = tmpFolder({ 'a/b/c/d.txt': 'deep\n' })
+    const expected = createHash('sha256')
+    expected.update('a/b/c/d.txt', 'utf8')
+    expected.update(Buffer.from([0]))
+    expected.update('deep\n', 'utf8')
+    expected.update(Buffer.from([0]))
+    expect(specFolderHash(dir)).toBe(expected.digest('hex'))
+  })
+
+  it('rewrites a literal backslash in a POSIX filename to "/" (documented quirk, spec hash only)', () => {
+    // On POSIX a backslash is an ordinary filename byte; collectFiles normalizes it to "/",
+    // so it collides with a truly nested path. Pin the behavior rather than assert it is ideal.
+    if (process.platform === 'win32') return // backslash is a real separator here
+    const literal = tmpFolder({ 'weird\\name.txt': 'x\n' })
+    const nested = tmpFolder({ 'weird/name.txt': 'x\n' })
+    expect(specFolderHash(literal)).toBe(specFolderHash(nested))
+  })
+
   it('sorts by UTF-8 bytes, not UTF-16 code units (astral vs BMP filenames)', () => {
     // U+FFFD (ef bf bd) precedes U+1F600 (f0 9f 98 80) in UTF-8 bytes, but JS default
     // sort compares UTF-16 code units, where the surrogate pair (d83d…) comes first.
@@ -140,5 +194,23 @@ describe('setHash', () => {
     const a = setHash({ x: '1'.repeat(64), y: '2'.repeat(64) })
     const b = setHash({ y: '2'.repeat(64), x: '1'.repeat(64) })
     expect(a).toBe(b)
+  })
+
+  it('rolls an empty member map up to the empty-input digest', () => {
+    expect(setHash({})).toBe(EMPTY)
+  })
+
+  it('sorts non-ASCII and escaped-character locators by UTF-8 bytes', () => {
+    const members: Record<string, string> = {
+      'a/ascii': 'a'.repeat(64),
+      'z/café': 'b'.repeat(64), // non-ASCII (é)
+      'm/back\\slash"quote': 'c'.repeat(64), // characters JSON must escape
+    }
+    const keys = Object.keys(members).sort((x, y) =>
+      Buffer.compare(Buffer.from(x, 'utf8'), Buffer.from(y, 'utf8')),
+    )
+    const expected = createHash('sha256')
+    for (const k of keys) expected.update(`${k}\n${members[k]}\n`, 'utf8')
+    expect(setHash(members)).toBe(expected.digest('hex'))
   })
 })

--- a/packages/cli/test/resolve-member.test.ts
+++ b/packages/cli/test/resolve-member.test.ts
@@ -79,7 +79,7 @@ describe('resolveMember discovery', () => {
 
   it('a named locator resolves without any lock diff', async () => {
     const cwd = project({ 'find-skills': entry('vercel-labs/agent-skills') })
-    const result = await resolveMember('vercel-labs/agent-skills@find-skills', { cwd, runner: noopInstall() })
+    const result = await resolveMember('vercel-labs/skills@find-skills', { cwd, runner: noopInstall() })
     expect(result.ok).toBe(true)
     if (result.ok) expect(result.data.skill).toBe('find-skills')
   })

--- a/packages/cli/test/resolve-member.test.ts
+++ b/packages/cli/test/resolve-member.test.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path'
 import { afterAll, describe, expect, it } from 'vitest'
 import { ErrorCodes } from '../src/errors.ts'
 import { specFolderHash } from '../src/hash.ts'
-import { resolveMember, SKILLS_DIR, type CommandRunner } from '../src/resolver.ts'
+import { locateMember, resolveMember, SKILLS_DIR, type CommandRunner } from '../src/resolver.ts'
 
 // Hermetic table over resolveMember's discovery branches: the runner stands in for the
 // upstream CLI, so every lock-diff path is reachable without a network or a real spawn.
@@ -177,5 +177,67 @@ describe('resolveMember discovery', () => {
     const result = await resolveMember('  ', { cwd, runner })
     expect(result.ok).toBe(false)
     expect(spawned).toBe(false)
+  })
+})
+
+describe('locateMember (finds already-installed skills)', () => {
+  it('resolves a named locator to its installed folder and spec hash', () => {
+    const cwd = project({ 'find-skills': entry('vercel-labs/agent-skills') })
+    const result = locateMember('vercel-labs/skills@find-skills', { cwd })
+    expect(result.ok, result.ok ? '' : result.error.message).toBe(true)
+    if (!result.ok) return
+    expect(result.data.skill).toBe('find-skills')
+    expect(result.data.computedHash).toBe(specFolderHash(join(cwd, SKILLS_DIR, 'find-skills')))
+    expect(result.data.sourceType).toBe('github')
+  })
+
+  it('resolves an unnamed locator via a unique source match', () => {
+    const cwd = project({
+      'find-skills': entry('vercel-labs/agent-skills'),
+      unrelated: entry('someone/else'),
+    })
+    const result = locateMember('vercel-labs/agent-skills', { cwd })
+    expect(result.ok, result.ok ? '' : result.error.message).toBe(true)
+    if (result.ok) expect(result.data.skill).toBe('find-skills')
+  })
+
+  it('narrows same-source entries by pinned ref', () => {
+    const cwd = project({ stable: entry('owner/repo', 'v1'), next: entry('owner/repo', 'v2') })
+    const result = locateMember('owner/repo#v2', { cwd })
+    expect(result.ok, result.ok ? '' : result.error.message).toBe(true)
+    if (!result.ok) return
+    expect(result.data.skill).toBe('next')
+    expect(result.data.ref).toBe('v2')
+  })
+
+  it('rejects an unnamed locator matching several skills with the candidates listed', () => {
+    const cwd = project({ alpha: entry('owner/repo'), beta: entry('owner/repo') })
+    const result = locateMember('owner/repo', { cwd })
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.error.code).toBe(ErrorCodes.RESOLVE_AMBIGUOUS)
+    expect(result.error.message).toContain('alpha, beta')
+    expect(result.error.data).toMatchObject({ candidates: ['alpha', 'beta'] })
+  })
+
+  it('fails an unnamed locator with zero source matches as MEMBER_NOT_INSTALLED', () => {
+    const cwd = project({ unrelated: entry('someone/else') })
+    const result = locateMember('owner/repo', { cwd })
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error.code).toBe(ErrorCodes.MEMBER_NOT_INSTALLED)
+  })
+
+  it('fails when the locked skill has no folder on disk', () => {
+    const cwd = project()
+    writeLock(cwd, { ghost: entry('owner/repo') }) // lock entry, but no folder
+    const result = locateMember('owner/repo', { cwd })
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error.code).toBe(ErrorCodes.MEMBER_NOT_INSTALLED)
+  })
+
+  it('rejects an empty locator', () => {
+    const result = locateMember('   ', { cwd: project() })
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error.code).toBe(ErrorCodes.RESOLVE_FAILED)
   })
 })

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: 'v8',
+      // Percent floors set just below the current baseline so ordinary churn passes but a
+      // real regression fails CI. Branches is lowest because it is the strictest metric.
+      thresholds: {
+        statements: 85,
+        branches: 75,
+        functions: 90,
+        lines: 90,
+      },
+    },
+  },
+})

--- a/packages/site/src/pages/index.astro
+++ b/packages/site/src/pages/index.astro
@@ -30,7 +30,7 @@ const manifest = `{
     verifies the installed bytes later — locally or in CI.
   </p>
 
-  <Code code="npx @skill-set/cli init my-tools vercel-labs/agent-skills@find-skills" lang="shellscript" theme={theme} />
+  <Code code="npx @skill-set/cli init my-tools vercel-labs/skills@find-skills hcjmartin/skills-repo@skill-creator" lang="shellscript" theme={theme} />
 
   <p>
     <a href="/cli/">CLI reference</a> · <a href="/spec/">Format specification</a> ·


### PR DESCRIPTION
Edge-case vectors for the spec hasher (binary/NUL, deep nesting, empty-set rollup, non-ASCII/escaped locators, realistic skill folder), locateMember coverage, and a percent coverage floor in vitest config. Also folds two example-locator fixes (init hint, site quickstart).