### PR TITLE
CLI branded intro line + TTY color fix

### DIFF
--- a/.changeset/orange-braces-introduce.md
+++ b/.changeset/orange-braces-introduce.md
@@ -1,0 +1,5 @@
+---
+'@skill-set/cli': minor
+---
+
+Add a branded one-line intro (`{skill-set} v<version> — <tagline>`) before commands in interactive TTY sessions. It prints to stderr so stdout stays pipeable, and is suppressed under `--json`, pipes, and CI. Also fixes terminal colors never being emitted on real TTYs (the injected-stream detection in `createUi` always tripped), and adds `Ui.accent()` — the brand accent `#ff5733` as truecolor, degrading to xterm-256 202 and then `redBright` by terminal depth.

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -33,7 +33,9 @@ const COMMANDS: Record<string, CommandEntry> = {
   remove: { usage: 'remove <set>', describe: 'Remove a set definition, optionally remove skills not otherwise in use', handler: cmdRemove },
 }
 
-const HELP = `skill-set — define, share, and install named, versioned sets of agent skills.
+const TAGLINE = 'define, share, and install named, versioned sets of agent skills'
+
+const HELP = `skill-set — ${TAGLINE}.
 
 Usage: skill-set <command> [args] [flags] [-- <args for the skills CLI>]
 
@@ -66,6 +68,8 @@ export interface RunOverrides {
   fetcher?: (url: string) => Promise<Result<string>>
   ci?: boolean
   interactive?: boolean
+  /** Overrides the intro-line TTY/stream detection (tests). --json still wins. */
+  intro?: boolean
   confirmAnswers?: boolean[]
   promptAnswers?: string[]
   stdout?: Writer
@@ -109,9 +113,20 @@ export async function run(argv: readonly string[], overrides: RunOverrides = {})
     interactive: overrides.interactive,
     confirmAnswers: overrides.confirmAnswers,
     promptAnswers: overrides.promptAnswers,
-    stdout,
-    stderr,
+    // Pass the raw overrides: createUi treats a present stdout as an injected stream and
+    // disables colors, so resolving the default here would turn colors off for real TTYs.
+    stdout: overrides.stdout,
+    stderr: overrides.stderr,
   })
+  // One branded line for humans, on stderr so stdout stays clean; pipes, CI, --json,
+  // and injected streams (tests) never see it.
+  const showIntro =
+    !json && (overrides.intro ?? (ui.interactive && overrides.stderr === undefined && process.stderr.isTTY === true))
+  if (showIntro) {
+    const wordmark = `${ui.accent('{')}${ui.style('bold', 'skill-set')}${ui.accent('}')}`
+    stderr.write(`${wordmark} ${ui.style('dim', `v${VERSION} — ${TAGLINE}`)}\n`)
+  }
+
   const ctx: CommandContext = {
     cwd: overrides.cwd ?? process.cwd(),
     ui,

--- a/packages/cli/src/ui.ts
+++ b/packages/cli/src/ui.ts
@@ -31,6 +31,8 @@ export interface Ui {
   warn(line: string): void
   /** Terminal styling; identity when colors are off (non-TTY, --json, or injected streams). */
   style(format: Parameters<typeof styleText>[0], text: string): string
+  /** Brand accent (#ff5733), degrading with terminal color depth; identity when colors are off. */
+  accent(text: string): string
   /**
    * Asks a yes/no question. --yes answers true without asking; when no prompt is possible
    * (--json, CI, no TTY) the caller gets a CONFIRM_REQUIRED error instead of a hang —
@@ -65,6 +67,14 @@ export function createUi(opts: UiOptions): Ui {
     },
     style(format, text) {
       return colors ? styleText(format, text) : text
+    },
+    accent(text) {
+      if (!colors) return text
+      // getColorDepth honours NO_COLOR/FORCE_COLOR/TERM; 24-bit → exact, 8-bit → xterm 202.
+      const depth = process.stdout.getColorDepth?.() ?? 4
+      if (depth >= 24) return `\x1b[38;2;255;87;51m${text}\x1b[39m`
+      if (depth >= 8) return `\x1b[38;5;202m${text}\x1b[39m`
+      return styleText('redBright', text)
     },
     async confirm(question, confirmOpts) {
       if (opts.yes) return { ok: true, data: true }

--- a/packages/cli/test/run.test.ts
+++ b/packages/cli/test/run.test.ts
@@ -122,3 +122,24 @@ describe('run — dispatch and meta-flags', () => {
     expect(VERSION).toBe(pkg.default.version)
   })
 })
+
+describe('run — intro line', () => {
+  it('prints the branded line on stderr, keeping stdout clean', async () => {
+    const w = writers()
+    await run(['banana'], { stdout: w.stdout, stderr: w.stderr, interactive: false, ci: false, intro: true })
+    const { out, err } = w.text()
+    expect(err).toContain(`{skill-set} v${VERSION} — define, share`)
+    expect(out).not.toContain('{skill-set}')
+  })
+
+  it('is suppressed with injected streams unless forced (pipes/CI/tests see nothing)', async () => {
+    const { err } = await cli(['banana'])
+    expect(err).not.toContain('{skill-set}')
+  })
+
+  it('--json wins even when the intro is forced on', async () => {
+    const w = writers()
+    await run(['banana', '--json'], { stdout: w.stdout, stderr: w.stderr, interactive: false, intro: true })
+    expect(w.text().err).not.toContain('{skill-set}')
+  })
+})


### PR DESCRIPTION
## Changes (`@skill-set/cli`, minor changeset)

- **Branded intro line** — interactive TTY sessions print `{skill-set} v0.1.2 — define, share, and install named, versioned sets of agent skills` before command output. Stderr only, so stdout stays pipeable; suppressed under `--json`, pipes/redirects, and CI. New `intro` override on `RunOverrides` keeps it testable.
- **Color fix** — `run.ts` always resolved `stdout`/`stderr` before passing them to `createUi`, so the injected-stream detection tripped on every real run and the CLI never emitted color anywhere (including the red `error` prefix). The raw overrides are now passed through, restoring colors on real TTYs while tests keep plain output.
- **`Ui.accent()`** — the brand accent `#ff5733` as 24-bit color, degrading to xterm-256 `202` then `redBright` per `getColorDepth()` (respects `NO_COLOR`/`FORCE_COLOR`/`TERM=dumb`); identity when colors are off.

## Test plan

- `pnpm run check` green: build, typecheck, lint, 348 tests (3 new: intro on stderr not stdout, suppressed for injected streams, `--json` wins even when forced).
- Verified under a real pty via an asciinema recording, including exact truecolor accent output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)