### PR TITLE
verify: lock-first by default, all-sets mode, drop the skills check delegation

### DIFF
--- a/.changeset/lazy-panthers-verify.md
+++ b/.changeset/lazy-panthers-verify.md
@@ -1,0 +1,5 @@
+---
+'@skill-set/cli': minor
+---
+
+`verify` now checks installed content against the set lock by default, everywhere — the previous `--frozen` semantics, with no CI/local divergence. With no set name it verifies every set in the project, with per-set results and an aggregate exit code (`3` if any set drifts). `--frozen` now means "require the lock": any targeted set without a lock exits `2`; `--no-frozen` is removed. When a set has no lock and `--frozen` is not given, verify falls back to a presence check and says explicitly that content was not verified. The delegated `npx skills check` staleness check is removed — verify never spawns the wrapped CLI; run `npx skills check` directly for per-skill staleness.

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Args after `--` pass through verbatim, e.g. `skill-set install demo -- --agent c
 
 ## Verify in CI
 
-`verify` re-hashes every installed member against the set lock, reports drifted skill content, and exits `3` on drift — identically on a laptop and in a pipeline. Without a set name it verifies every set. `--frozen` adds strictness for CI: a set without a committed lock fails with exit `2` instead of falling back to a presence check.
+`verify` re-hashes every installed member against the set lock, reports drifted content, and exits `3` on drift (identical in CI). Without a set name it verifies every set. `--frozen` adds strictness for pipelines: a set without a committed lock fails with exit `2` instead of falling back to a presence check.
 
 ![verify --frozen catches drifted skill content](docs/demo-verify-drift.gif)
 

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ npx @skill-set/cli install frontend
 # Record exactly which bytes each member resolved to, in frontend.skill-set.lock.json
 npx @skill-set/cli lock frontend
 
-# Check the installation; --frozen recomputes every member's content hash against the lock
-npx @skill-set/cli verify frontend --frozen
+# Verify the installation — recomputes every member's content hash against the lock
+npx @skill-set/cli verify frontend
 ```
 
 Publish the manifest and lock anywhere HTTPS-reachable (`share` exports both), and anyone can `add` your set.
@@ -64,7 +64,7 @@ Publish the manifest and lock anywhere HTTPS-reachable (`share` exports both), a
 | `build [<set>] [--lock]` | Regenerate SKILL-SET.md files and the skill-sets.json index |
 | `lock <set>` | Record each member's installed content in a set-lock |
 | `share [<set>] [--manifest <path>] [--output <dir>]` | Export a shareable manifest and lock |
-| `verify <set> [--frozen]` | Check installed members against the set (frozen: byte-exact) |
+| `verify [<set>] [--frozen]` | Verify installed content against each set lock (frozen: require the lock) |
 | `update <set>` | Update members via the skills CLI, then re-lock |
 | `remove <set>` | Remove a set definition, optionally remove skills not otherwise in use |
 
@@ -86,14 +86,14 @@ Args after `--` pass through verbatim, e.g. `skill-set install demo -- --agent c
 
 ## Verify in CI
 
-`verify <set> --frozen` re-hashes every installed member against the set lock, reports drifted skill content, and exits `3` on drift. In CI, frozen is already the default whenever a lock exists.
+`verify` re-hashes every installed member against the set lock, reports drifted skill content, and exits `3` on drift — identically on a laptop and in a pipeline. Without a set name it verifies every set. `--frozen` adds strictness for CI: a set without a committed lock fails with exit `2` instead of falling back to a presence check.
 
 ![verify --frozen catches drifted skill content](docs/demo-verify-drift.gif)
 
 ```yaml
 # .github/workflows/ci.yml
-- run: npx @skill-set/cli verify frontend
-  # fails the job on drift (exit 3): installed skill bytes no longer match the lock
+- run: npx @skill-set/cli verify frontend --frozen
+  # fails the job on drift (exit 3) or a missing committed lock (exit 2)
 ```
 
 ## Source locators

--- a/packages/cli/src/commands/verify.ts
+++ b/packages/cli/src/commands/verify.ts
@@ -62,15 +62,18 @@ export async function cmdVerify(args: string[], ctx: CommandContext): Promise<Co
     failures.find((f) => f.code === ErrorCodes.DRIFT)?.code ??
     failures.find((f) => f.code === ErrorCodes.FROZEN_NO_LOCK)?.code ??
     failures[0]!.code
+  const hint =
+    code === ErrorCodes.DRIFT
+      ? 'Reinstall from manifests ("skill-set install <set>"), or accept the current state ("skill-set lock <set>").'
+      : code === ErrorCodes.FROZEN_NO_LOCK
+        ? 'Create the missing locks with "skill-set lock <set>" and commit them.'
+        : 'Install missing members with "skill-set install <set>".'
   return {
     ok: false,
     error: new SkillSetError(
       code,
       `${failures.length} of ${plural(names.length, 'set')} failed verification:\n\n${failures.map((f) => f.message).join('\n\n')}`,
-      {
-        hint: 'Reinstall from manifests ("skill-set install <set>"), or accept the current state ("skill-set lock <set>").',
-        data: { sets },
-      },
+      { hint, data: { sets } },
     ),
   }
 }

--- a/packages/cli/src/commands/verify.ts
+++ b/packages/cli/src/commands/verify.ts
@@ -1,58 +1,103 @@
 import { existsSync } from 'node:fs'
 import { join } from 'node:path'
-import ci from 'ci-info'
 import { ErrorCodes, SkillSetError } from '../errors.ts'
 import { specFolderHash } from '../hash.ts'
 import { LOCK_SUFFIX, type SetLock } from '../lock.ts'
 import type { Manifest } from '../manifest.ts'
-import { loadLockIfPresent, loadManifest } from '../project.ts'
-import { buildCheckInvocation, locateMember, SKILLS_DIR } from '../resolver.ts'
-import { runCommand } from '../spawn.ts'
-import { formatInvocation, plural, splitFlags, usageError, type CommandContext, type CommandResult } from './context.ts'
+import { listSetNames, loadLockIfPresent, loadManifest } from '../project.ts'
+import { locateMember, SKILLS_DIR } from '../resolver.ts'
+import { plural, splitFlags, usageError, type CommandContext, type CommandResult } from './context.ts'
 
-export const VERIFY_USAGE = 'skill-set verify <set> [--frozen|--no-frozen]'
+export const VERIFY_USAGE = 'skill-set verify [<set>] [--frozen]'
 
 export async function cmdVerify(args: string[], ctx: CommandContext): Promise<CommandResult> {
-  const split = splitFlags(args, ['--frozen', '--no-frozen'], VERIFY_USAGE)
+  const split = splitFlags(args, ['--frozen'], VERIFY_USAGE)
   if (!split.ok) return split
   const { flags, positionals } = split.data
-  const [name, ...extra] = positionals
-  if (name === undefined || extra.length > 0) return usageError('verify takes exactly one set name', VERIFY_USAGE)
+  if (positionals.length > 1) return usageError('verify takes at most one set name', VERIFY_USAGE)
+  const frozen = flags.has('--frozen')
 
-  const manifest = loadManifest(ctx.cwd, name)
-  if (!manifest.ok) return manifest
-  const lock = loadLockIfPresent(ctx.cwd, name)
-  if (!lock.ok) return lock
-
-  // In CI, frozen is the default whenever a lock exists (explicit flags always win).
-  const inCi = ctx.ci ?? ci.isCI
-  const frozen = flags.has('--frozen') ? true : flags.has('--no-frozen') ? false : inCi && lock.data !== undefined
+  const single = positionals.length === 1
+  const names = single ? [positionals[0]!] : listSetNames(ctx.cwd)
+  if (names.length === 0) {
+    ctx.ui.out('No sets found — nothing to verify.')
+    ctx.ui.out(ctx.ui.style('dim', 'Create one with "skill-set init <name>".'))
+    return { ok: true, data: { sets: [] } }
+  }
 
   ctx.ui.out(
-    frozen
-      ? `Verifying installed skill-set ${JSON.stringify(name)} — validating contents against the lock hash...`
-      : `Verifying installed skill-set ${JSON.stringify(name)} — checking installed skills against the set...`,
+    single
+      ? `Verifying installed skill-set ${JSON.stringify(names[0])} — validating contents against the set lock...`
+      : `Verifying ${plural(names.length, 'installed skill-set')} — validating contents against the set locks...`,
   )
-  return frozen ? verifyFrozen(ctx, name, manifest.data, lock.data) : verifyDefault(ctx, name, manifest.data, lock.data)
-}
 
-/** Byte-exact verification: recompute every member's content hash against the set-lock. */
-function verifyFrozen(
-  ctx: CommandContext,
-  name: string,
-  manifest: Manifest,
-  lock: SetLock | undefined,
-): CommandResult {
-  if (lock === undefined) {
-    return {
-      ok: false,
-      error: new SkillSetError(ErrorCodes.FROZEN_NO_LOCK, `Missing skill-set lock file for ${JSON.stringify(name)} — frozen verify needs ${name}${LOCK_SUFFIX}`, {
-        hint: `Create one with "skill-set lock ${name}" and commit it.`,
-        data: { name, expected: `${name}${LOCK_SUFFIX}` },
-      }),
+  const sets: unknown[] = []
+  const failures: SkillSetError[] = []
+  for (const name of names) {
+    const manifest = loadManifest(ctx.cwd, name)
+    if (!manifest.ok) return manifest
+    const lock = loadLockIfPresent(ctx.cwd, name)
+    if (!lock.ok) return lock
+    const result =
+      lock.data !== undefined
+        ? verifyAgainstLock(ctx, name, manifest.data, lock.data)
+        : frozen
+          ? missingLock(name)
+          : verifyPresence(ctx, name, manifest.data)
+    if (result.ok) {
+      sets.push(result.data)
+    } else {
+      failures.push(result.error)
+      sets.push({ ...(result.error.data as Record<string, unknown>), error: result.error.code })
+      ctx.ui.out(`${ctx.ui.style('red', '✗')} ${name}: ${failureLabel(result.error.code)}`)
     }
   }
 
+  if (failures.length === 0) return { ok: true, data: single ? sets[0] : { sets } }
+  if (single) return { ok: false, error: failures[0]! }
+
+  // Aggregate severity: any drift means the project does not match its locks (exit 3);
+  // otherwise a frozen run missing a lock is precondition-shaped (exit 2).
+  const code =
+    failures.find((f) => f.code === ErrorCodes.DRIFT)?.code ??
+    failures.find((f) => f.code === ErrorCodes.FROZEN_NO_LOCK)?.code ??
+    failures[0]!.code
+  return {
+    ok: false,
+    error: new SkillSetError(
+      code,
+      `${failures.length} of ${plural(names.length, 'set')} failed verification:\n\n${failures.map((f) => f.message).join('\n\n')}`,
+      {
+        hint: 'Reinstall from manifests ("skill-set install <set>"), or accept the current state ("skill-set lock <set>").',
+        data: { sets },
+      },
+    ),
+  }
+}
+
+function failureLabel(code: string): string {
+  if (code === ErrorCodes.DRIFT) return 'does not match its lock'
+  if (code === ErrorCodes.FROZEN_NO_LOCK) return 'no set lock (--frozen requires one)'
+  return 'skills missing'
+}
+
+function missingLock(name: string): CommandResult {
+  return {
+    ok: false,
+    error: new SkillSetError(ErrorCodes.FROZEN_NO_LOCK, `Missing skill-set lock file for ${JSON.stringify(name)} — frozen verify needs ${name}${LOCK_SUFFIX}`, {
+      hint: `Create one with "skill-set lock ${name}" and commit it.`,
+      data: { name, expected: `${name}${LOCK_SUFFIX}` },
+    }),
+  }
+}
+
+/** Byte-exact verification: recompute every member's content hash against the set-lock. */
+function verifyAgainstLock(
+  ctx: CommandContext,
+  name: string,
+  manifest: Manifest,
+  lock: SetLock,
+): CommandResult {
   const manifestMembers = new Set(manifest.skills)
   const added = manifest.skills.filter((locator) => !(locator in lock.skills))
   const removed = Object.keys(lock.skills).filter((locator) => !manifestMembers.has(locator))
@@ -77,7 +122,7 @@ function verifyFrozen(
   const problems = drifted.length + missing.length + added.length + removed.length
   if (problems === 0) {
     ctx.ui.out(`${ctx.ui.style('green', '✓')} ${name}: all set skills match the set lock (${checked}/${checked})`)
-    return { ok: true, data: { name, mode: 'frozen', checked } }
+    return { ok: true, data: { name, mode: 'lock', checked } }
   }
 
   // Every problem in one report — a partial drift list hides the real repair size.
@@ -94,59 +139,21 @@ function verifyFrozen(
       `Set ${JSON.stringify(name)} does not match its lock — ${plural(problems, 'problem')}:\n  - ${lines.join('\n  - ')}`,
       {
         hint: `Reinstall from manifest ("skill-set install ${name}"), or accept the current state ("skill-set lock ${name}").`,
-        data: { name, mode: 'frozen', checked, drifted, missing, added, removed },
+        data: { name, mode: 'lock', checked, drifted, missing, added, removed },
       },
     ),
   }
 }
 
-/** Presence verification plus the delegated upstream staleness check; no hashes recomputed. */
-async function verifyDefault(
-  ctx: CommandContext,
-  name: string,
-  manifest: Manifest,
-  lock: SetLock | undefined,
-): Promise<CommandResult> {
+/** No lock to verify against: presence check only, with an explicit content-not-verified note. */
+function verifyPresence(ctx: CommandContext, name: string, manifest: Manifest): CommandResult {
   const present: string[] = []
   const missing: Array<{ locator: string; message: string }> = []
   for (const locator of manifest.skills) {
-    const entry = lock?.skills[locator]
-    if (entry !== undefined) {
-      if (existsSync(join(ctx.cwd, SKILLS_DIR, entry.skill))) present.push(locator)
-      else missing.push({ locator, message: `skill folder missing (${SKILLS_DIR}/${entry.skill})` })
-      continue
-    }
     const located = locateMember(locator, { cwd: ctx.cwd })
     if (located.ok) present.push(locator)
     else missing.push({ locator, message: located.error.message })
   }
-
-  // Staleness is delegated to the upstream check; its findings inform, they do not fail verify.
-  const invocation = buildCheckInvocation()
-  let checkExit: number | undefined
-  if (ctx.dryRun) {
-    ctx.ui.out(ctx.ui.style('dim', `would run: ${formatInvocation(invocation, ctx.passthrough)}`))
-  } else {
-    ctx.ui.out(ctx.ui.style('dim', `running: ${formatInvocation(invocation, ctx.passthrough)}`))
-    const args = ctx.passthrough.length === 0 ? invocation.args : [...invocation.args, ...ctx.passthrough]
-    const check = await (ctx.runner ?? runCommand)(invocation.command, args, {
-      cwd: ctx.cwd,
-      env: invocation.env,
-      capture: ctx.ui.json,
-    })
-    checkExit = check.ok ? check.data.exitCode : undefined
-    if (checkExit !== 0) {
-      ctx.ui.warn(
-        check.ok
-          ? `upstream "skills check" exited with code ${String(checkExit)} — see its output above`
-          : `upstream "skills check" could not run: ${check.ok === false ? check.error.message : ''}`,
-      )
-    }
-  }
-
-  ctx.ui.out('Checks run:')
-  ctx.ui.out(`  - skill members (${present.length}/${manifest.skills.length} found)`)
-  ctx.ui.out('  - upstream staleness check')
 
   if (missing.length > 0) {
     return {
@@ -154,11 +161,11 @@ async function verifyDefault(
       error: new SkillSetError(
         ErrorCodes.MEMBER_NOT_INSTALLED,
         `${missing.length} of ${manifest.skills.length} skills of ${JSON.stringify(name)} are not installed:\n  - ${missing.map((m) => `${m.locator}: ${m.message}`).join('\n  - ')}`,
-        { hint: `Install with "skill-set install ${name}".`, data: { name, mode: 'default', present, missing } },
+        { hint: `Install with "skill-set install ${name}".`, data: { name, mode: 'presence', present, missing } },
       ),
     }
   }
   ctx.ui.out(`${ctx.ui.style('green', '✓')} ${name}: all set skills present (${present.length}/${manifest.skills.length})`)
-  ctx.ui.out('WARNING: skill content was not checked — use --frozen to verify content matches the set lock.')
-  return { ok: true, data: { name, mode: 'default', present, missing: [], upstreamCheckExit: checkExit } }
+  ctx.ui.warn(`${JSON.stringify(name)} has no set lock — content was not verified. Create one with "skill-set lock ${name}".`)
+  return { ok: true, data: { name, mode: 'presence', present, missing: [] } }
 }

--- a/packages/cli/src/resolver.ts
+++ b/packages/cli/src/resolver.ts
@@ -80,11 +80,6 @@ export function buildAddInvocation(locator: string, opts?: { global?: boolean })
   return { command: 'npx', args, env }
 }
 
-/** Builds the pinned upstream check invocation: reports member staleness, changes nothing. */
-export function buildCheckInvocation(): SkillsInvocation {
-  return withTelemetryOptOut(['-y', `skills@${SKILLS_PIN}`, 'check'])
-}
-
 /** Builds the pinned upstream update invocation for installed skills (project scope, prompt-suppressed). */
 export function buildUpdateInvocation(skills: readonly string[]): SkillsInvocation {
   return withTelemetryOptOut(['-y', `skills@${SKILLS_PIN}`, 'update', ...skills, '-p', '--yes'])

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -28,7 +28,7 @@ const COMMANDS: Record<string, CommandEntry> = {
   build: { usage: 'build [<set>] [--lock]', describe: 'Regenerate SKILL-SET.md files and the skill-sets.json index', handler: cmdBuild },
   lock: { usage: 'lock <set>', describe: "Record each member's installed content in a set-lock", handler: cmdLock },
   share: { usage: 'share [<set>] [--manifest <path>] [--output <dir>]', describe: 'Export a shareable manifest and lock', handler: cmdShare },
-  verify: { usage: 'verify <set> [--frozen]', describe: 'Check installed members against the set (frozen: byte-exact)', handler: cmdVerify },
+  verify: { usage: 'verify [<set>] [--frozen]', describe: 'Verify installed content against each set lock (frozen: require the lock)', handler: cmdVerify },
   update: { usage: 'update <set>', describe: 'Update members via the skills CLI, then re-lock', handler: cmdUpdate },
   remove: { usage: 'remove <set>', describe: 'Remove a set definition, optionally remove skills not otherwise in use', handler: cmdRemove },
 }

--- a/packages/cli/test/cli-commands.test.ts
+++ b/packages/cli/test/cli-commands.test.ts
@@ -13,7 +13,7 @@ import type { Writer } from '../src/ui.ts'
 
 // End-to-end command tests over real tmp projects, hermetic via a stateful fake of the
 // pinned upstream CLI: add installs a folder + lock entry, update rewrites content,
-// remove deletes both, check exits 0. Every spawn is captured for invocation asserts.
+// remove deletes both. Every spawn is captured for invocation asserts.
 
 const dirs: string[] = []
 afterAll(() => {
@@ -83,7 +83,6 @@ function fakeSkills(cwd: string): FakeSkills {
       writeRunLock(lock)
       return ok
     }
-    if (verb === 'check') return ok
     return { ok: true, data: { exitCode: 2, stdout: '', stderr: '' } }
   }
   return { runner, calls, captureFlags }
@@ -188,30 +187,30 @@ describe('authoring round-trip: init → install → lock → build → verify �
     expect(Object.keys(index.sets)).toEqual(['my-tools'])
   })
 
-  it('verify passes in both modes while content matches the lock', async () => {
+  it('verify passes with and without --frozen while content matches the lock, spawning nothing', async () => {
+    const spawnsBefore = fake.calls.length
     expect((await cli(cwd, fake, ['verify', 'my-tools'])).code).toBe(0)
     expect((await cli(cwd, fake, ['verify', 'my-tools', '--frozen'])).code).toBe(0)
+    expect(fake.calls.length).toBe(spawnsBefore)
   })
 
-  it('frozen verify names every drifted member and exits 3', async () => {
+  it('verify names every drifted member and exits 3, by default and under --frozen', async () => {
     appendFileSync(join(cwd, SKILLS_DIR, 'alpha', 'SKILL.md'), 'tampered\n')
-    const { code, err } = await cli(cwd, fake, ['verify', 'my-tools', '--frozen'])
+    const spawnsBefore = fake.calls.length
+    const { code, err } = await cli(cwd, fake, ['verify', 'my-tools'])
     expect(code).toBe(3)
     expect(err).toContain('hcjmartin/alpha-repo@alpha')
     expect(err).toContain('content drifted — expected')
-    // Default mode does not recompute content, so it stays green and says so.
-    const soft = await cli(cwd, fake, ['verify', 'my-tools'])
-    expect(soft.code).toBe(0)
-    expect(soft.out).toContain('Checks run:')
-    expect(soft.out).toContain('- skill members (2/2 found)')
-    expect(soft.out).toContain('all set skills present (2/2)')
-    expect(soft.out).toContain('WARNING: skill content was not checked — use --frozen')
+    expect((await cli(cwd, fake, ['verify', 'my-tools', '--frozen'])).code).toBe(3)
+    // Content verification is local hashing only — never a wrapped-CLI spawn.
+    expect(fake.calls.length).toBe(spawnsBefore)
   })
 
-  it('in CI, verify defaults to frozen when a lock exists', async () => {
-    const { code } = await cli(cwd, fake, ['verify', 'my-tools'], { ci: true })
-    expect(code).toBe(3)
-    expect((await cli(cwd, fake, ['verify', 'my-tools', '--no-frozen'], { ci: true })).code).toBe(0)
+  it('verify behaves identically in and out of CI', async () => {
+    expect((await cli(cwd, fake, ['verify', 'my-tools'], { ci: true })).code).toBe(3)
+    expect((await cli(cwd, fake, ['verify', 'my-tools'], { ci: false })).code).toBe(3)
+    // --no-frozen is gone: lock verification is the only default, so the escape hatch is meaningless.
+    expect((await cli(cwd, fake, ['verify', 'my-tools', '--no-frozen'])).code).toBe(2)
   })
 
   it('update delegates to the pinned upstream and re-locks', async () => {
@@ -1118,9 +1117,24 @@ describe('--json mode', () => {
     expect(envelope.data.installed).toHaveLength(1)
     // Every upstream spawn under --json runs captured, so child output cannot corrupt stdout.
     expect(fake.captureFlags).toEqual([true])
-    const human = await cli(cwd, fake, ['verify', 'j'])
-    expect(human.code).toBe(0)
-    expect(fake.captureFlags.at(-1)).not.toBe(true)
+  })
+
+  it('verifying all sets reports per-set results in the envelope', async () => {
+    const cwd = project()
+    const fake = fakeSkills(cwd)
+    await cli(cwd, fake, ['init', 'a', 'hcjmartin/alpha-repo@alpha'])
+    await cli(cwd, fake, ['init', 'b', 'hcjmartin/beta-repo@beta'])
+    await cli(cwd, fake, ['install', 'a'])
+    await cli(cwd, fake, ['install', 'b'])
+    await cli(cwd, fake, ['lock', 'a'])
+    const { code, out } = await cli(cwd, fake, ['verify', '--json'])
+    expect(code).toBe(0)
+    const envelope = JSON.parse(out) as { ok: boolean; data: { sets: Array<{ name: string; mode: string }> } }
+    expect(envelope.ok).toBe(true)
+    expect(envelope.data.sets).toEqual([
+      expect.objectContaining({ name: 'a', mode: 'lock' }),
+      expect.objectContaining({ name: 'b', mode: 'presence' }),
+    ])
   })
 
   it('maps a drift error to the envelope and exit 3', async () => {
@@ -1143,7 +1157,7 @@ describe('usage errors', () => {
   it.each([
     [['install']],
     [['lock']],
-    [['verify']],
+    [['verify', 'a', 'b']],
     [['update']],
     [['remove']],
     [['add']],
@@ -1189,7 +1203,7 @@ describe('usage errors', () => {
   })
 })
 
-describe('build --lock and delegated-spawn provenance', () => {
+describe('build --lock', () => {
   it('build --lock writes the page, the lock, and the index in one pass', async () => {
     const cwd = project()
     const fake = fakeSkills(cwd)
@@ -1202,22 +1216,67 @@ describe('build --lock and delegated-spawn provenance', () => {
     expect(existsSync(join(cwd, SETS_DIR, INDEX_FILENAME))).toBe(true)
   })
 
-  it('verify labels the delegated check and warns on its non-zero exit without failing', async () => {
+})
+
+describe('verify', () => {
+  it('without a lock falls back to a presence check and says content was not verified', async () => {
     const cwd = project()
     const fake = fakeSkills(cwd)
     await cli(cwd, fake, ['init', 'w', 'hcjmartin/alpha-repo@alpha'])
     await cli(cwd, fake, ['install', 'w'])
-    const grumpyCheck: typeof fake = {
-      ...fake,
-      runner: async (command, args, opts) =>
-        args[2] === 'check'
-          ? { ok: true, data: { exitCode: 3, stdout: '', stderr: '' } }
-          : fake.runner(command, args, opts),
-    }
-    const { code, out, err } = await cli(cwd, grumpyCheck, ['verify', 'w'])
+    const spawnsBefore = fake.calls.length
+    const { code, out, err } = await cli(cwd, fake, ['verify', 'w'])
     expect(code).toBe(0)
-    expect(out).toContain('running: npx -y skills@1.5.14 check')
-    expect(err).toContain('upstream "skills check" exited with code 3')
+    expect(out).toContain('all set skills present (1/1)')
+    expect(err).toContain('content was not verified')
+    expect(err).toContain('skill-set lock w')
+    expect(fake.calls.length).toBe(spawnsBefore)
+  })
+
+  it('with no set name verifies every set; one drifted set fails the run with exit 3', async () => {
+    const cwd = project()
+    const fake = fakeSkills(cwd)
+    await cli(cwd, fake, ['init', 'clean', 'hcjmartin/alpha-repo@alpha'])
+    await cli(cwd, fake, ['init', 'dirty', 'hcjmartin/beta-repo@beta'])
+    await cli(cwd, fake, ['install', 'clean'])
+    await cli(cwd, fake, ['install', 'dirty'])
+    await cli(cwd, fake, ['lock', 'clean'])
+    await cli(cwd, fake, ['lock', 'dirty'])
+    appendFileSync(join(cwd, SKILLS_DIR, 'beta', 'SKILL.md'), 'tampered\n')
+    const { code, out, err } = await cli(cwd, fake, ['verify'])
+    expect(code).toBe(3)
+    expect(out).toContain('clean: all set skills match the set lock (1/1)')
+    expect(out).toContain('dirty: does not match its lock')
+    expect(err).toContain('1 of 2 sets failed verification')
+    expect(err).toContain('content drifted — expected')
+  })
+
+  it('aggregates mixed lock/no-lock sets: lax without --frozen, exit 2 with it', async () => {
+    const cwd = project()
+    const fake = fakeSkills(cwd)
+    await cli(cwd, fake, ['init', 'locked', 'hcjmartin/alpha-repo@alpha'])
+    await cli(cwd, fake, ['init', 'unlocked', 'hcjmartin/beta-repo@beta'])
+    await cli(cwd, fake, ['install', 'locked'])
+    await cli(cwd, fake, ['install', 'unlocked'])
+    await cli(cwd, fake, ['lock', 'locked'])
+    const lax = await cli(cwd, fake, ['verify'])
+    expect(lax.code).toBe(0)
+    expect(lax.err).toContain('"unlocked" has no set lock')
+    const strict = await cli(cwd, fake, ['verify', '--frozen'])
+    expect(strict.code).toBe(2)
+    expect(strict.out).toContain('unlocked: no set lock (--frozen requires one)')
+    expect(strict.err).toContain('unlocked.skill-set.lock.json')
+    // Drift outranks a missing lock in the aggregate exit.
+    appendFileSync(join(cwd, SKILLS_DIR, 'alpha', 'SKILL.md'), 'tampered\n')
+    expect((await cli(cwd, fake, ['verify', '--frozen'])).code).toBe(3)
+  })
+
+  it('with no sets in the project reports nothing to verify and exits 0', async () => {
+    const cwd = project()
+    const fake = fakeSkills(cwd)
+    const { code, out } = await cli(cwd, fake, ['verify'])
+    expect(code).toBe(0)
+    expect(out).toContain('No sets found — nothing to verify.')
   })
 })
 

--- a/packages/site/src/pages/cli.md
+++ b/packages/site/src/pages/cli.md
@@ -25,7 +25,7 @@ skill-set/<version> (wraps skills@1.5.14, pinned)
 | [`build`](#build) | `build [<set>] [--lock]` | Regenerate SKILL-SET.md files and the skill-sets.json index |
 | [`lock`](#lock) | `lock <set>` | Record each member's installed content in a set-lock |
 | [`share`](#share) | `share [<set>] [--manifest <path>] [--output <dir>]` | Export a shareable manifest and lock |
-| [`verify`](#verify) | `verify <set> [--frozen]` | Check installed members against the set (frozen: byte-exact) |
+| [`verify`](#verify) | `verify [<set>] [--frozen]` | Verify installed content against each set lock (frozen: require the lock) |
 | [`update`](#update) | `update <set>` | Update members via the skills CLI, then re-lock |
 | [`remove`](#remove) | `remove <set>` | Remove a set definition, optionally remove skills not otherwise in use |
 
@@ -86,15 +86,12 @@ The manifest and lock are written to `.agents/skills/skill-sets/_share/<set>/` (
 ### verify
 
 ```shellscript
-skill-set verify <set> [--frozen|--no-frozen]
+skill-set verify [<set>] [--frozen]
 ```
 
-Two modes:
+Recomputes every member's content hash and compares it to the set-lock — the same check everywhere, laptop or CI. All problems are reported in one pass — drifted members with expected and actual hashes, missing folders, and manifest/lock membership differences — and the command exits with code 3. Without a set name, every set in the project is verified; any drifted set fails the run. Verify never spawns the wrapped skills CLI; for per-skill staleness against upstream sources, run `npx skills check` directly.
 
-- **Default** — checks every member is present at its installed location and delegates a staleness check to `npx skills check` (informational; its findings do not fail the verify). Content is not compared; the command says so.
-- **Frozen** (`--frozen`) — recomputes every member's content hash and compares it to the set-lock. All problems are reported in one pass — drifted members with expected and actual hashes, missing folders, and manifest/lock membership differences — and the command exits with code 3. Running `--frozen` without a lock is a precondition failure (exit 2) with a hint to create one.
-
-In CI, frozen is the default whenever a set-lock exists; `--no-frozen` opts out. See [verifying in CI](/faq/#how-do-i-verify-a-set-in-ci).
+When a set has no lock, verify falls back to checking that every member is present, says explicitly that content was not verified, and hints to create a lock with `skill-set lock <set>`. `--frozen` turns that fallback into a failure: any targeted set without a lock is a precondition error (exit 2). See [verifying in CI](/faq/#how-do-i-verify-a-set-in-ci).
 
 ![Terminal recording: skill-set verify --frozen catching drift against the lock.](/demo-verify-drift.gif)
 
@@ -137,7 +134,7 @@ installs the set's skills for those agents only. See `npx skills --help` for wha
 With `--json`, every run — including crashes — emits exactly one JSON envelope on stdout:
 
 ```json
-{ "ok": true, "command": "verify", "data": { "name": "frontend", "mode": "frozen", "checked": 4 } }
+{ "ok": true, "command": "verify", "data": { "name": "frontend", "mode": "lock", "checked": 4 } }
 ```
 
 ```json
@@ -162,5 +159,5 @@ With `--json`, every run — including crashes — emits exactly one JSON envelo
 | `0` | Success |
 | `1` | Error — anything not covered below |
 | `2` | Usage — bad arguments, a prompt blocked without `--yes`, or `verify --frozen` without a set-lock |
-| `3` | Drift — frozen verify found installed content that does not match the set-lock |
+| `3` | Drift — verify found installed content that does not match the set-lock |
 | `4` | Conflict — a member source pinned to different refs across sets |

--- a/packages/site/src/pages/cli.md
+++ b/packages/site/src/pages/cli.md
@@ -89,7 +89,9 @@ The manifest and lock are written to `.agents/skills/skill-sets/_share/<set>/` (
 skill-set verify [<set>] [--frozen]
 ```
 
-Recomputes every member's content hash and compares it to the set-lock — the same check everywhere, laptop or CI. All problems are reported in one pass — drifted members with expected and actual hashes, missing folders, and manifest/lock membership differences — and the command exits with code 3. Without a set name, every set in the project is verified; any drifted set fails the run. Verify never spawns the wrapped skills CLI; for per-skill staleness against upstream sources, run `npx skills check` directly.
+Recomputes every member's content hash and validates it against the set-lock (identical in CI). Reports drifted members with expected and actual hashes, missing folders, and membership differences; exits `3` on drift. Called without a `<set>`, verifies every set in the project.
+
+For per-skill staleness against upstream sources, use `npx skills check`.
 
 When a set has no lock, verify falls back to checking that every member is present, says explicitly that content was not verified, and hints to create a lock with `skill-set lock <set>`. `--frozen` turns that fallback into a failure: any targeted set without a lock is a precondition error (exit 2). See [verifying in CI](/faq/#how-do-i-verify-a-set-in-ci).
 

--- a/packages/site/src/pages/faq.md
+++ b/packages/site/src/pages/faq.md
@@ -36,15 +36,15 @@ Commit the set-lock (create it with `skill-set lock <set>`), then run verify in 
 - run: npx @skill-set/cli verify frontend --frozen
 ```
 
-Frozen verify recomputes every member's content hash from the bytes on disk and compares it to the lock. On mismatch it exits with code 3 and reports **all** problems in one pass — each drifted member with its expected and actual hash, missing folders, and any manifest/lock membership differences — so one run shows the full repair size.
+Verify recomputes every member's content hash from the bytes on disk and compares it to the lock — that is the default, identical everywhere. On mismatch it exits with code 3 and reports **all** problems in one pass — each drifted member with its expected and actual hash, missing folders, and any manifest/lock membership differences — so one run shows the full repair size.
 
-In CI environments, frozen is already the default whenever a set-lock exists, so `npx @skill-set/cli verify frontend` behaves the same there; the explicit flag also makes the intent clear to readers. The `--frozen` flag is the strict path anywhere else too: the default (non-frozen) verify only checks presence and delegates a staleness check to `npx skills check`.
+What `--frozen` adds is strictness about the lock itself: without it, a set that has no lock falls back to a presence check (with an explicit note that content was not verified); with it, a missing lock fails with exit 2. In a pipeline you want the flag. Omit the set name to verify every set in the project in one run.
 
 Two related exit codes matter for pipelines: `2` means the verify could not run as asked (for example `--frozen` with no committed lock), `3` means it ran and found drift. Use `--json` for machine-readable results.
 
 ## Should I commit the lock?
 
-Yes, if you want reproducibility or frozen verify — that is its purpose. The lock is deterministic (sorted keys, no timestamps; identical inputs produce identical bytes), so diffs are small and merges stay clean. Without a lock, `install` still works from the manifest alone; you just lose byte-exact verification and idempotent skips.
+Yes, if you want reproducibility or content verification — that is its purpose. The lock is deterministic (sorted keys, no timestamps; identical inputs produce identical bytes), so diffs are small and merges stay clean. Without a lock, `install` still works from the manifest alone; you just lose byte-exact verification and idempotent skips.
 
 ## What is verified, and when?
 
@@ -53,7 +53,7 @@ Trust is layered, and each layer has a defined job:
 1. **Before fetching**: `add` only reaches out to recognised skill-set hosts without asking; any other host requires an explicit confirmation first. Redirects cannot escape to unrecognised hosts.
 2. **Before anything is shown or written**: the fetched manifest must pass schema validation. Validation errors report the problem structurally and never repeat fetched content back into your terminal.
 3. **When adding a shared set (optional, recommended for third-party sets)**: if the share URL carries a hash fragment (`…skill-set.json#sha256=<hash>`) or you pass `--hash`, and/or the author published their lock beside the manifest, `add` verifies the installed content against it. If an already-installed local copy does not match, `add` re-fetches that member in a clean staging project and checks the published content without changing your installed copy. Content that does not match the provided hash or the published lock is not kept — the set files are removed and the command fails.
-4. **After that, over time**: your committed lock plus `verify --frozen` (the CI default) catches any later drift, byte-exactly, member by member.
+4. **After that, over time**: your committed lock plus `verify` catches any later drift, byte-exactly, member by member.
 
 Skill resolution itself is delegated to the pinned `skills@1.5.14` CLI with prompts suppressed — the trust decisions all happen in the layers above, not in the delegated fetch.
 

--- a/packages/site/src/pages/faq.md
+++ b/packages/site/src/pages/faq.md
@@ -36,9 +36,9 @@ Commit the set-lock (create it with `skill-set lock <set>`), then run verify in 
 - run: npx @skill-set/cli verify frontend --frozen
 ```
 
-Verify recomputes every member's content hash from the bytes on disk and compares it to the lock — that is the default, identical everywhere. On mismatch it exits with code 3 and reports **all** problems in one pass — each drifted member with its expected and actual hash, missing folders, and any manifest/lock membership differences — so one run shows the full repair size.
+Verify recomputes every member's content hash from the bytes on disk and validates it against the lock (identical in CI). On mismatch it exits `3`, reporting each drifted member with its expected and actual hash, missing folders, and membership differences. Omit the set name to verify every set in the project.
 
-What `--frozen` adds is strictness about the lock itself: without it, a set that has no lock falls back to a presence check (with an explicit note that content was not verified); with it, a missing lock fails with exit 2. In a pipeline you want the flag. Omit the set name to verify every set in the project in one run.
+`--frozen` adds strictness about the lock itself: without it, a set that has no lock falls back to a presence check (with an explicit note that content was not verified); with it, a missing lock fails with exit `2`. In a pipeline you want the flag.
 
 Two related exit codes matter for pipelines: `2` means the verify could not run as asked (for example `--frozen` with no committed lock), `3` means it ran and found drift. Use `--json` for machine-readable results.
 


### PR DESCRIPTION
Closes #21 — implements the agreed design: `skill-set` is a set-operations tool first; upstream operations belong to the upstream tool.

## Changes (`@skill-set/cli`, minor changeset)

- **`verify [<set>]` verifies content against the set lock by default, everywhere** — the previous `--frozen` semantics, with the CI/local divergence removed (no CI special-case). Verify never spawns the wrapped CLI; `buildCheckInvocation` is deleted.
- **No set name → verifies all sets** (same optional-positional pattern as `build`, via `listSetNames`): per-set result lines, aggregate exit code with drift (3) outranking a frozen missing lock (2).
- **No lock + no `--frozen`** → presence check with an explicit "content was not verified" warning and a `skill-set lock <set>` hint (exit 0 when members are present).
- **`--frozen` now means "require the lock"** — a targeted set without one exits `2` (`FROZEN_NO_LOCK`). Existing CI scripts keep working and gain strictness. `--no-frozen` is removed.
- **Per-skill staleness** is out of scope for verify — run `npx skills check` directly (docs point there).

## Why

Discovered while recording the README demos: under a real TTY, non-frozen verify's delegated `npx skills check` opened an interactive "Update scope" menu and hung (it was the only wrapped invocation without `--yes`); in piped runs it silently auto-updated an installed skill. Full investigation and design discussion in #21. The command named `verify` now does what the README's first sentence promises, by default.

## Docs (same merge — sites are public)

README (commands table, quickstart comment, "Verify in CI" section now recommends `verify frontend --frozen` in pipelines), `cli.md` verify section + JSON example + exit-code wording, `faq.md` CI answer. `spec/draft/README.md` untouched: it never referenced the delegation and the new default exceeds its default-verify floor.

## Tests

360 passed (5 added, 5 rewritten): no-spawn assertions on both verify modes, no-lock fallback, multi-set aggregation incl. drift-outranks-missing-lock, no-sets exit 0, `--json` per-set envelope, CI parity. `NODE_OPTIONS= pnpm run check` green (build, typecheck, lint, tests).

## Note for review

`ctx.ci`/`RunOverrides.ci` is now read by no command (verify was the only consumer). Left in place deliberately — the CI-parity test exercises it and removal ripples through every test's overrides; candidate for a follow-up cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)