### PR TITLE
FIX: Contain add provenance text, pre-probe multi-skill members. MOD: Correct ref-pin docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Args after `--` pass through verbatim, e.g. `skill-set install demo -- --agent c
 
 ## Source locators
 
-Members are listed as source-locator strings, optionally pinned with `#<tag-or-commit>`. The reference CLI delegates resolution to `npx skills`, which accepts GitHub shorthands (`owner/repo@skill-name`), git/GitLab URLs, local paths, and well-known HTTPS domains. The format itself treats locators as opaque — see [the spec](spec/draft/README.md) for the exact rules.
+Members are listed as source-locator strings, optionally pinned with `#<tag-or-branch>`. The reference CLI delegates resolution to `npx skills`, which accepts GitHub shorthands (`owner/repo@skill-name`), git/GitLab URLs, local paths, and well-known HTTPS domains. Its pinned resolver checks out refs through `git clone --branch`, so commit SHA pins are not supported. The format itself treats locators as opaque — see [the spec](spec/draft/README.md) for the exact rules.
 
 ## Where things install
 

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -19,6 +19,30 @@ const FETCH_TIMEOUT_MS = 30_000
 
 const HEX64 = /^[a-f0-9]{64}$/
 
+/**
+ * Renders valid-but-untrusted manifest text as terminal-safe, visibly quoted data.
+ * This is deliberately output-only: the fetched manifest remains byte-for-byte unchanged.
+ */
+function quotedRemoteText(value: string, maxLength?: number): string {
+  const singleLine = [...value]
+    .filter((character) => {
+      const codePoint = character.codePointAt(0)!
+      return !(
+        codePoint <= 0x1f ||
+        (codePoint >= 0x7f && codePoint <= 0x9f) ||
+        codePoint === 0x2028 ||
+        codePoint === 0x2029
+      )
+    })
+    .join('')
+  const characters = [...singleLine]
+  const contained =
+    maxLength !== undefined && characters.length > maxLength
+      ? `${characters.slice(0, Math.max(0, maxLength - 1)).join('')}…`
+      : singleLine
+  return JSON.stringify(contained)
+}
+
 type VerifiedAgainst = 'sidecar' | 'hash' | 'both'
 
 interface VerificationDetail {
@@ -88,12 +112,18 @@ export async function cmdAdd(args: string[], ctx: CommandContext): Promise<Comma
 
   // The provenance summary comes before anything is written or installed (spec §3),
   // and before the already-exists refusal so the user sees what was fetched.
-  ctx.ui.out(`Set ${JSON.stringify(name)} v${manifest.data.version}${manifest.data.description === undefined ? '' : ` — ${manifest.data.description}`}`)
-  if (manifest.data.author !== undefined) ctx.ui.out(ctx.ui.style('dim', `author: ${manifest.data.author.name}`))
+  ctx.ui.out(
+    `Set ${JSON.stringify(name)} v${manifest.data.version}${manifest.data.description === undefined ? '' : ` — ${quotedRemoteText(manifest.data.description, 128)}`}`,
+  )
+  if (manifest.data.author !== undefined) {
+    ctx.ui.out(ctx.ui.style('dim', `author: ${quotedRemoteText(manifest.data.author.name, 64)}`))
+  }
   ctx.ui.out(`${plural(manifest.data.skills.length, 'member skill')}:`)
   for (const locator of manifest.data.skills) {
     const parsed = parseLocator(locator)
-    ctx.ui.out(`  ${locator} ${ctx.ui.style('dim', `(source ${parsed.source}${parsed.ref === undefined ? '' : `, pinned ${parsed.ref}`})`)}`)
+    ctx.ui.out(
+      `  ${quotedRemoteText(locator)} ${ctx.ui.style('dim', `(source ${quotedRemoteText(parsed.source)}${parsed.ref === undefined ? '' : `, pinned ${quotedRemoteText(parsed.ref)}`})`)}`,
+    )
   }
 
   const paths = setPaths(ctx.cwd, name)

--- a/packages/cli/src/resolver.ts
+++ b/packages/cli/src/resolver.ts
@@ -80,6 +80,13 @@ export function buildAddInvocation(locator: string, opts?: { global?: boolean })
   return { command: 'npx', args, env }
 }
 
+/** Builds the pinned upstream no-write discovery invocation for an unnamed member. */
+export function buildListInvocation(locator: string): SkillsInvocation {
+  const { source, ref } = parseLocator(locator)
+  const sourceArg = ref === undefined ? source : `${source}#${ref}`
+  return withTelemetryOptOut(['-y', `skills@${SKILLS_PIN}`, 'add', sourceArg, '--list'])
+}
+
 /** Builds the pinned upstream check invocation: reports member staleness, changes nothing. */
 export function buildCheckInvocation(): SkillsInvocation {
   return withTelemetryOptOut(['-y', `skills@${SKILLS_PIN}`, 'check'])
@@ -287,6 +294,14 @@ export async function resolveMember(
     return { ok: false, error: reservedNameError([locator]) }
   }
 
+  // An explicit @skill already narrows the upstream selection to one. For an unnamed
+  // locator, use the pinned CLI's documented --list mode before the mutating add spawn.
+  if (parsed.skill === undefined) {
+    const probe = await probeMemberCount(locator, opts)
+    if (!probe.ok) return probe
+    if (probe.data !== 1) return preInstallDiscoveryFailure(locator, parsed.source, probe.data)
+  }
+
   const before = readLockSkills(opts.cwd)
   if (!before.ok) return before
 
@@ -384,6 +399,90 @@ export async function resolveMember(
       ...(entry.ref === undefined ? {} : { ref: entry.ref }),
     },
   }
+}
+
+async function probeMemberCount(
+  locator: string,
+  opts: {
+    cwd: string
+    runner?: CommandRunner
+    extraArgs?: readonly string[]
+    onSetsDirRestored?: () => void
+  },
+): Promise<Result<number>> {
+  const invocation = buildListInvocation(locator)
+  const args =
+    opts.extraArgs === undefined || opts.extraArgs.length === 0
+      ? invocation.args
+      : [...invocation.args, ...opts.extraArgs]
+  const guard = snapshotSetsDir(opts.cwd)
+  const run = await (opts.runner ?? runCommand)(invocation.command, args, {
+    cwd: opts.cwd,
+    env: invocation.env,
+    capture: true,
+  })
+  if (restoreSetsDir(opts.cwd, guard)) opts.onSetsDirRestored?.()
+  if (!run.ok) return run
+  if (run.data.exitCode !== 0) {
+    return fail(
+      ErrorCodes.RESOLVE_FAILED,
+      `Probing ${JSON.stringify(locator)} failed: the skills CLI exited with code ${run.data.exitCode}`,
+      {
+        hint: 'The captured skills output is in data.stderr.',
+        data: { locator, exitCode: run.data.exitCode, stderr: run.data.stderr.slice(-2000) },
+      },
+    )
+  }
+
+  const plain = stripTerminalSequences(`${run.data.stdout}\n${run.data.stderr}`)
+  const count = plain.match(/\bFound ([1-9]\d*) skills?\b/)?.[1]
+  if (count === undefined) {
+    return fail(
+      ErrorCodes.RESOLVE_FAILED,
+      `Probing ${JSON.stringify(locator)} failed: the skills CLI did not report how many skills are available`,
+      {
+        hint: `This CLI expects the documented --list output from skills@${SKILLS_PIN}; check upstream compatibility.`,
+        data: { locator },
+      },
+    )
+  }
+  return { ok: true, data: Number.parseInt(count, 10) }
+}
+
+/** Removes C0/C1 controls and ANSI CSI sequences from captured upstream status output. */
+function stripTerminalSequences(value: string): string {
+  let plain = ''
+  for (let index = 0; index < value.length; index++) {
+    const codePoint = value.codePointAt(index)!
+    if (codePoint === 0x1b) {
+      if (value.codePointAt(index + 1) === 0x5b) {
+        index += 2
+        while (index < value.length) {
+          const final = value.codePointAt(index)!
+          if (final >= 0x40 && final <= 0x7e) break
+          index++
+        }
+      }
+      continue
+    }
+    if (codePoint <= 0x1f || (codePoint >= 0x7f && codePoint <= 0x9f)) {
+      if (codePoint === 0x0a) plain += '\n'
+      continue
+    }
+    plain += value[index]!
+  }
+  return plain
+}
+
+function preInstallDiscoveryFailure(locator: string, source: string, count: number): Result<never> {
+  return fail(
+    ErrorCodes.RESOLVE_AMBIGUOUS,
+    `Member ${JSON.stringify(locator)} matches ${count} available skills. A set member must resolve to exactly one skill. Nothing was installed.`,
+    {
+      hint: `Name the skill in the set member, e.g. ${JSON.stringify(`${source}@<skill-name>`)}.`,
+      data: { locator, source, count },
+    },
+  )
 }
 
 /**

--- a/packages/cli/test/cli-commands.test.ts
+++ b/packages/cli/test/cli-commands.test.ts
@@ -49,6 +49,9 @@ function fakeSkills(cwd: string): FakeSkills {
     const writeRunLock = (lock: unknown): void => writeFileSync(runLockPath, `${JSON.stringify(lock, null, 2)}\n`)
     const verb = args[2]
     if (verb === 'add') {
+      if (args.includes('--list')) {
+        return { ok: true, data: { exitCode: 0, stdout: '◇ Found 1 skill\n', stderr: '' } }
+      }
       const sourceArg = args[3]!
       const hashAt = sourceArg.lastIndexOf('#')
       const source = hashAt > 0 ? sourceArg.slice(0, hashAt) : sourceArg
@@ -158,7 +161,8 @@ describe('authoring round-trip: init → install → lock → build → verify �
     expect(existsSync(join(cwd, SKILLS_DIR, 'beta-repo'))).toBe(true)
     // Named member forwards --skill; both spawns are the pinned invocation.
     expect(fake.calls[0]).toEqual(['npx', '-y', 'skills@1.5.14', 'add', 'hcjmartin/alpha-repo', '--skill', 'alpha', '--yes'])
-    expect(fake.calls[1]).toEqual(['npx', '-y', 'skills@1.5.14', 'add', 'hcjmartin/beta-repo', '--yes'])
+    expect(fake.calls[1]).toEqual(['npx', '-y', 'skills@1.5.14', 'add', 'hcjmartin/beta-repo', '--list'])
+    expect(fake.calls[2]).toEqual(['npx', '-y', 'skills@1.5.14', 'add', 'hcjmartin/beta-repo', '--yes'])
   })
 
   it('lock records the installed content', async () => {
@@ -604,6 +608,59 @@ describe('add — remote content is never echoed', () => {
     expect(summary[2]).toContain('"owner/repo@skill#v1next"')
     expect(summary[2]).toContain('(source "owner/repo", pinned "v1next")')
     expect(readFileSync(join(cwd, SETS_DIR, 'contained', 'contained.skill-set.json'), 'utf8')).toBe(manifest)
+  })
+})
+
+describe('multi-skill members are rejected before install', () => {
+  function rejectsAsMulti(fake: FakeSkills, calls: string[][]): CommandRunner {
+    return async (command, args, opts) => {
+      calls.push([command, ...args])
+      if (args.includes('--list')) {
+        expect(opts?.capture).toBe(true)
+        return { ok: true, data: { exitCode: 0, stdout: '\u001b[?25h◇ Found \u001b[32m2\u001b[0m skills\n', stderr: '' } }
+      }
+      return fake.runner(command, args, opts)
+    }
+  }
+
+  it('install writes no skill folder or upstream lock entry', async () => {
+    const cwd = project()
+    const fake = fakeSkills(cwd)
+    await cli(cwd, fake, ['init', 'multi', 'owner/multi-repo'])
+    const calls: string[][] = []
+
+    const { code, err } = await cli(cwd, { ...fake, runner: rejectsAsMulti(fake, calls) }, ['install', 'multi'])
+
+    expect(code).toBe(1)
+    expect(err).toContain('matches 2 available skills')
+    expect(err).toContain('Nothing was installed')
+    expect(calls).toEqual([['npx', '-y', 'skills@1.5.14', 'add', 'owner/multi-repo', '--list']])
+    expect(existsSync(join(cwd, 'skills-lock.json'))).toBe(false)
+    expect(existsSync(join(cwd, SKILLS_DIR, 'one'))).toBe(false)
+    expect(existsSync(join(cwd, SKILLS_DIR, 'two'))).toBe(false)
+  })
+
+  it('add reaches only the no-write probe and creates no skill folder or upstream lock entry', async () => {
+    const cwd = project()
+    const fake = fakeSkills(cwd)
+    const calls: string[][] = []
+    const url = 'https://skill-set.md/multi.skill-set.json'
+    const manifest = `${JSON.stringify({ name: 'multi', version: '1.0.0', skills: ['owner/multi-repo'] }, null, 2)}\n`
+    const fetcher: RunOverrides['fetcher'] = async (requested) =>
+      requested === url
+        ? { ok: true as const, data: manifest }
+        : { ok: false as const, error: new Error('no sidecar') as never }
+
+    const { code, err } = await cli(cwd, { ...fake, runner: rejectsAsMulti(fake, calls) }, ['add', url, '--yes'], {
+      fetcher,
+    })
+
+    expect(code).toBe(1)
+    expect(err).toContain('matches 2 available skills')
+    expect(calls).toEqual([['npx', '-y', 'skills@1.5.14', 'add', 'owner/multi-repo', '--list']])
+    expect(existsSync(join(cwd, 'skills-lock.json'))).toBe(false)
+    expect(existsSync(join(cwd, SKILLS_DIR, 'one'))).toBe(false)
+    expect(existsSync(join(cwd, SKILLS_DIR, 'two'))).toBe(false)
   })
 })
 

--- a/packages/cli/test/cli-commands.test.ts
+++ b/packages/cli/test/cli-commands.test.ts
@@ -385,7 +385,7 @@ describe('add', () => {
 
     const added = await cli(cwd, fake, ['add', 'https://skill-set.md/fetched-set.skill-set.json', '--yes'], { fetcher })
     expect(added.code).toBe(0)
-    expect(added.out).toContain('Set "fetched-set" v1.0.0 — A shared set.')
+    expect(added.out).toContain('Set "fetched-set" v1.0.0 — "A shared set."')
     // Written verbatim: the fetched bytes are exactly what lands on disk.
     expect(readFileSync(join(cwd, SETS_DIR, 'fetched-set', 'fetched-set.skill-set.json'), 'utf8')).toBe(manifestText)
     expect(existsSync(join(cwd, SKILLS_DIR, 'gamma'))).toBe(true)
@@ -554,6 +554,56 @@ describe('add — remote content is never echoed', () => {
     const envelope = JSON.parse(out.trim()) as { ok: boolean; error: { code: string } }
     expect(envelope.ok).toBe(false)
     expect(envelope.error.code).toBe('ERR_SKILLSET_INVALID_JSON')
+  })
+
+  it('contains valid remote free text in the provenance summary without changing manifest bytes', async () => {
+    const cwd = project()
+    const fake = fakeSkills(cwd)
+    const description = `${'d'.repeat(120)}\n\u001b[31mINSTRUCTION${'x'.repeat(30)}`
+    const author = `${'a'.repeat(62)}\r\nAUTHOR${'y'.repeat(20)}`
+    const locator = 'owner/\u0085repo@skill#v1\u2028next'
+    const manifest = `${JSON.stringify(
+      {
+        name: 'contained',
+        version: '1.0.0',
+        description,
+        author: { name: author },
+        skills: [locator],
+      },
+      null,
+      2,
+    )}\n`
+    const url = 'https://skill-set.md/contained.skill-set.json'
+    const fetcher: RunOverrides['fetcher'] = async (requested) =>
+      requested === url
+        ? { ok: true as const, data: manifest }
+        : { ok: false as const, error: new Error('no sidecar') as never }
+
+    const { code, out } = await cli(cwd, fake, ['add', url, '--yes'], { fetcher })
+
+    expect(code).toBe(0)
+    const summary = out.split('\n').filter((line) => line.startsWith('Set ') || line.startsWith('author:') || line.startsWith('  "'))
+    expect(summary).toHaveLength(3)
+    expect(
+      summary.every((line) =>
+        [...line].every((character) => {
+          const codePoint = character.codePointAt(0)!
+          return !(
+            codePoint <= 0x1f ||
+            (codePoint >= 0x7f && codePoint <= 0x9f) ||
+            codePoint === 0x2028 ||
+            codePoint === 0x2029
+          )
+        }),
+      ),
+    ).toBe(true)
+    expect(summary[0]).toBe(`Set "contained" v1.0.0 — "${'d'.repeat(120)}[31mINS…"`)
+    expect([...(JSON.parse(summary[0]!.split(' — ')[1]!) as string)]).toHaveLength(128)
+    expect(summary[1]).toBe(`author: "${'a'.repeat(62)}A…"`)
+    expect([...(JSON.parse(summary[1]!.slice('author: '.length)) as string)]).toHaveLength(64)
+    expect(summary[2]).toContain('"owner/repo@skill#v1next"')
+    expect(summary[2]).toContain('(source "owner/repo", pinned "v1next")')
+    expect(readFileSync(join(cwd, SETS_DIR, 'contained', 'contained.skill-set.json'), 'utf8')).toBe(manifest)
   })
 })
 

--- a/packages/cli/test/resolve-member.test.ts
+++ b/packages/cli/test/resolve-member.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterAll, describe, expect, it } from 'vitest'
@@ -53,7 +53,13 @@ function installs(
   after: Record<string, LockEntry>,
   opts?: { skipFolders?: boolean },
 ): CommandRunner {
-  return async () => {
+  return async (_command, args) => {
+    if (args.includes('--list')) {
+      return {
+        ok: true,
+        data: { exitCode: 0, stdout: `\u001b[?25h◇ Found \u001b[32m${Object.keys(after).length}\u001b[0m skills\n`, stderr: '' },
+      }
+    }
     writeLock(cwd, after)
     if (opts?.skipFolders !== true) for (const skill of Object.keys(after)) addFolder(cwd, skill)
     return { ok: true, data: { exitCode: 0, stdout: '', stderr: '' } }
@@ -62,7 +68,10 @@ function installs(
 
 /** A runner that touches nothing — upstream's in-place update of an already-present skill. */
 function noopInstall(): CommandRunner {
-  return async () => ({ ok: true, data: { exitCode: 0, stdout: '', stderr: '' } })
+  return async (_command, args) => ({
+    ok: true,
+    data: { exitCode: 0, stdout: args.includes('--list') ? '◇ Found 1 skill\n' : '', stderr: '' },
+  })
 }
 
 describe('resolveMember discovery', () => {
@@ -128,14 +137,35 @@ describe('resolveMember discovery', () => {
     expect(result.error.hint).toContain('"owner/repo@<skill-name>"')
   })
 
-  it('a fresh install of several skills fails the one-skill rule with candidates', async () => {
+  it('a fresh install of several skills fails the one-skill rule before writing anything', async () => {
     const cwd = project()
     const runner = installs(cwd, { one: entry('owner/repo'), two: entry('owner/repo') })
     const result = await resolveMember('owner/repo', { cwd, runner })
     expect(result.ok).toBe(false)
     if (result.ok) return
     expect(result.error.code).toBe(ErrorCodes.RESOLVE_AMBIGUOUS)
-    expect(result.error.data).toMatchObject({ candidates: ['one', 'two'] })
+    expect(result.error.message).toContain('matches 2 available skills')
+    expect(result.error.message).toContain('Nothing was installed')
+    expect(result.error.data).toMatchObject({ count: 2 })
+    expect(existsSync(join(cwd, 'skills-lock.json'))).toBe(false)
+    expect(existsSync(join(cwd, SKILLS_DIR, 'one'))).toBe(false)
+    expect(existsSync(join(cwd, SKILLS_DIR, 'two'))).toBe(false)
+  })
+
+  it('fails closed when successful --list output has no dependable count', async () => {
+    const cwd = project()
+    let calls = 0
+    const runner: CommandRunner = async () => {
+      calls++
+      return { ok: true, data: { exitCode: 0, stdout: 'Available Skills\n', stderr: '' } }
+    }
+    const result = await resolveMember('owner/repo', { cwd, runner })
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.error.code).toBe(ErrorCodes.RESOLVE_FAILED)
+    expect(result.error.message).toContain('did not report how many skills are available')
+    expect(calls).toBe(1)
+    expect(existsSync(join(cwd, 'skills-lock.json'))).toBe(false)
   })
 
   it('a named skill absent from the lock fails with RESOLVE_NO_LOCK_ENTRY', async () => {

--- a/packages/cli/test/resolver.test.ts
+++ b/packages/cli/test/resolver.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { buildConfig } from '../src/config.ts'
-import { buildAddInvocation, parseLocator, SKILLS_PIN } from '../src/resolver.ts'
+import { buildAddInvocation, buildListInvocation, parseLocator, SKILLS_PIN } from '../src/resolver.ts'
 
 // One row per source kind the upstream resolver accepts, plus grammar edges.
 const TABLE: Array<{
@@ -94,5 +94,19 @@ describe('buildAddInvocation', () => {
   it('appends --global when requested', () => {
     const inv = buildAddInvocation('owner/repo@x', { global: true })
     expect(inv.args[inv.args.length - 1]).toBe('--global')
+  })
+})
+
+describe('buildListInvocation', () => {
+  it('uses the pinned upstream no-write list mode and preserves a ref', () => {
+    const inv = buildListInvocation('owner/repo#v1.2.0')
+    expect([inv.command, ...inv.args]).toEqual([
+      'npx',
+      '-y',
+      `skills@${SKILLS_PIN}`,
+      'add',
+      'owner/repo#v1.2.0',
+      '--list',
+    ])
   })
 })

--- a/packages/site/src/pages/index.astro
+++ b/packages/site/src/pages/index.astro
@@ -13,7 +13,7 @@ const manifest = `{
   "skills": [
     "hcjmartin/skills-repo@skill-creator",
     "vercel-labs/agent-skills@web-design-guidelines#v2.1.0",
-    "https://github.com/hcjmartin/agent-skills@review-code#8f7e6d5",
+    "https://github.com/hcjmartin/agent-skills@review-code#v1.2.0",
     "https://flocker.md/skills@research-notes"
   ]
 }`
@@ -52,7 +52,8 @@ const manifest = `{
     One file per set, <code>&lt;name&gt;.skill-set.json</code>, validated by a
     <a href="/schema/draft/skill-set.schema.json">published JSON Schema</a>. Members are the same source locators the
     <a href="https://skills.sh">skills CLI</a> accepts — GitHub shorthands, git URLs, local paths, well-known HTTPS
-    domains — optionally pinned with <code>#tag-or-commit</code>.
+    domains — optionally pinned with <code>#tag-or-branch</code>. The pinned resolver checks out refs through
+    <code>git clone --branch</code>, so commit SHA pins are not supported.
   </p>
   <Code code={manifest} lang="json" theme={theme} />
 

--- a/spec/draft/README.md
+++ b/spec/draft/README.md
@@ -18,7 +18,7 @@ One file per set, named `<name>.skill-set.json`, validating against [`skill-set.
   "skills": [
     "hcjmartin/skills-repo@skill-creator",
     "vercel-labs/agent-skills@web-design-guidelines#v2.1.0",
-    "https://github.com/hcjmartin/agent-skills@review-code#8f7e6d5",
+    "https://github.com/hcjmartin/agent-skills@review-code#v1.2.0",
     "https://flocker.md/skills@research-notes"
   ]
 }
@@ -32,9 +32,11 @@ One file per set, named `<name>.skill-set.json`, validating against [`skill-set.
 | `description` | — | What the set is for. |
 | `author` | — | `{ name, url?, organization?, uri? }` — attribution; `uri` is a stable identity URI. |
 | `homepage` | — | Docs or source page for the set. |
-| `skills[]` | ✔ | Member skills as **opaque source-locator strings**, optionally pinned with `#<tag-or-commit>`. |
+| `skills[]` | ✔ | Member skills as **opaque source-locator strings**, optionally pinned with `#<tag-or-branch>`. |
 
 Locators are opaque to this format: their grammar is owned by the resolver an implementation uses (the reference CLI delegates to `npx skills`, which accepts GitHub shorthands, git/GitLab URLs, local paths, and well-known HTTPS domains). The format only requires that a locator is a non-empty string resolving to exactly one skill.
+
+The reference resolver checks out pinned refs through `git clone --branch`, so its pins must name a tag or branch; commit SHAs are not supported.
 
 A member's **skill name** is the directory name of its installed folder — `.agents/skills/<skill-name>/` — as determined by the resolver at installation. Skill names are lowercase alphanumerics with single hyphens.
 
@@ -89,7 +91,7 @@ An optional, generated lock records exactly which bytes each member resolved to.
     "hcjmartin/skills-repo@skill-creator": {
       "skill": "skill-creator",
       "sourceType": "github",
-      "ref": "a1b2c3d",
+      "ref": "v1.2.0",
       "computedHash": "781b…"
     }
   }
@@ -111,7 +113,7 @@ Per-member entry:
 | `skill` | ✔ | The installed skill name (§1). |
 | `computedHash` | ✔ | The member content hash (§6), lowercase hex. |
 | `sourceType` | — | Resolver-reported source kind (e.g. `github`, `git`, `well-known`). The vocabulary is resolver-defined; implementations MUST NOT reject unknown values. |
-| `ref` | — | Resolver-reported resolved ref (tag or commit), when the source has one. |
+| `ref` | — | Resolver-reported resolved ref (tag or branch), when the source has one. |
 
 **`setHash`**: the SHA-256, in lowercase hex, over the concatenation — in UTF-8-byte-order of the locator — of `<locator>\n<computedHash>\n` for every member, all strings encoded as UTF-8.
 

--- a/spec/draft/examples/lock/valid/minimal.skill-set.lock.json
+++ b/spec/draft/examples/lock/valid/minimal.skill-set.lock.json
@@ -8,7 +8,7 @@
       "skill": "skill-creator",
       "computedHash": "781bd6d3f9b19f8c9af6b53d8d0e4876d0183841b565db34ca7092ffa412d111",
       "sourceType": "github",
-      "ref": "a1b2c3d"
+      "ref": "v1.2.0"
     }
   }
 }

--- a/spec/draft/examples/valid/full.skill-set.json
+++ b/spec/draft/examples/valid/full.skill-set.json
@@ -13,7 +13,7 @@
   "skills": [
     "hcjmartin/skills-repo@skill-creator",
     "vercel-labs/agent-skills@web-design-guidelines#v2.1.0",
-    "https://github.com/hcjmartin/agent-skills@review-code#8f7e6d5",
+    "https://github.com/hcjmartin/agent-skills@review-code#v1.2.0",
     "https://flocker.md/skills@research-notes"
   ]
 }

--- a/spec/draft/skill-set.lock.schema.json
+++ b/spec/draft/skill-set.lock.schema.json
@@ -58,7 +58,7 @@
             "minLength": 1
           },
           "ref": {
-            "description": "Resolver-reported resolved ref (tag or commit), when the source has one.",
+            "description": "Resolver-reported resolved ref (tag or branch), when the source has one.",
             "type": "string",
             "minLength": 1
           }

--- a/spec/draft/skill-set.schema.json
+++ b/spec/draft/skill-set.schema.json
@@ -61,7 +61,7 @@
       "format": "uri"
     },
     "skills": {
-      "description": "Member skills as opaque source-locator strings, optionally pinned with '#<tag-or-commit>'. Order carries no meaning; duplicates are invalid.",
+      "description": "Member skills as opaque source-locator strings, optionally pinned with '#<tag-or-branch>'. Order carries no meaning; duplicates are invalid.",
       "type": "array",
       "minItems": 1,
       "uniqueItems": true,


### PR DESCRIPTION
Closes #5, closes #8, closes #13.

## Changes (`@skill-set/cli`, patch changeset)

- **#5 — provenance containment on `add`**: remote manifest free text (description, author, member locators) renders in the provenance summary as quoted, control-stripped (C0/C1 + U+2028/29), length-capped data — description 128 chars, author 64, ellipsis on truncation. Output only; the fetched bytes are stored untouched.
- **#8 — multi-skill members fail before anything is written**: unnamed locators (no `@skill`) get a no-write pre-probe via the pinned upstream `skills add <source> --list`; a source with more than one skill fails early as `RESOLVE_AMBIGUOUS` with a `source@<skill-name>` hint. Applies to both `install` and `add`. Unparseable probe output fails closed with an upstream-compat hint.
- **#13 — pin docs accuracy**: `#<tag-or-commit>` → `#<tag-or-branch>` across README, spec, both JSON schemas, examples, and the site; SHA-looking examples replaced with tag examples; `git clone --branch` caveat noted.

## Design note

The #8 probe parses the pinned upstream CLI's human-readable `Found N skills` output — stable for the pin, revisited when the pin bumps; it fails closed if the shape changes. Upstream `--json` (vercel-labs/skills#1686) would replace this parsing entirely.

## Merge with main

Includes a merge of current main (verify redesign #22, 0.3.0 #23). One conflict in `resolver.ts`: kept the new `buildListInvocation`, accepted main's deletion of `buildCheckInvocation` — no semantic overlap (the probe runs only from install/add; redesigned verify never spawns).

## Tests

365 passed on the merged tree (provenance cap + unchanged-manifest-bytes, multi-skill rejection for install and add with no-write assertions, fail-closed probe parsing, `buildListInvocation` unit tests). `NODE_OPTIONS= pnpm run check` green: build, typecheck, lint, tests.