### PR TITLE
FIX: Plan and confirm remove/update before any mutation

### DIFF
--- a/.changeset/mutation-plan-confirm.md
+++ b/.changeset/mutation-plan-confirm.md
@@ -1,0 +1,5 @@
+---
+'@skill-set/cli': minor
+---
+
+`remove` and `update` now plan before they mutate. `remove` prints the full removal plan (set artifacts, removable and kept skills, the upstream cleanup command) and collects both confirmations up front; accepted skill cleanup runs before the set definition is deleted, so a failed cleanup leaves the set installed for a retry. `update` prints the update plan and the upstream mutation boundary, and asks one confirmation before spawning; `--yes`, `--json`, and non-interactive runs are unaffected, and `--dry-run` now lists the members while spawning nothing.

--- a/packages/cli/src/commands/remove.ts
+++ b/packages/cli/src/commands/remove.ts
@@ -37,18 +37,16 @@ export async function cmdRemove(args: string[], ctx: CommandContext): Promise<Co
 
   ctx.ui.out(`Removing skill-set ${JSON.stringify(name)}...`)
 
+  // Plan the whole operation before prompting or mutating. Besides making the preview truthful,
+  // this ensures a broken sibling manifest or lock cannot strand a half-removed set.
+  const counted = referenceCount(ctx, name, manifest.data.skills)
+  if (!counted.ok) return counted
+  const { removable, kept: skillsKept } = counted.data
+  printRemovalPlan(ctx, name, source, removable, skillsKept)
+
   if (ctx.dryRun) {
-    const counted = referenceCount(ctx, name, manifest.data.skills)
-    if (!counted.ok) return counted
-    const { removable, kept } = counted.data
-    ctx.ui.out(`would remove: set ${JSON.stringify(name)} (from ${source}) — definition, lock, and generated files`)
-    if (removable.length > 0) {
-      ctx.ui.out(`would offer to also remove its skills (${removable.join(', ')})`)
-      ctx.ui.out(ctx.ui.style('dim', `  would run on yes: ${formatInvocation(buildRemoveInvocation(removable), ctx.passthrough)}`))
-    }
-    for (const k of kept) ctx.ui.out(ctx.ui.style('dim', `  would keep ${k.skill ?? k.member}: ${k.reason}`))
     ctx.ui.out(`${ctx.ui.style('green', '✓')} dry run — no files changed, no skills removed`)
-    return { ok: true, data: { name, dryRun: true, wouldRemoveSkills: removable, skillsKept: kept } }
+    return { ok: true, data: { name, dryRun: true, wouldRemoveSkills: removable, skillsKept } }
   }
 
   // Prompt 1: a required gate. Declining leaves everything untouched.
@@ -59,7 +57,70 @@ export async function cmdRemove(args: string[], ctx: CommandContext): Promise<Co
     return { ok: true, data: { name, removed: false } }
   }
 
-  // Act at once on the confirmed step: drop this set's own files and refresh the index.
+  // Prompt 2 is collected before either operation begins. It remains an optional convenience
+  // offer, so non-interactive callers preserve the old set-only behavior unless they pass --yes.
+  let removeSkills = false
+  if (removable.length > 0) {
+    const alsoRemove = await ctx.ui.confirm(`Also remove its skills (${removable.join(', ')})?`, { optional: true })
+    if (!alsoRemove.ok) return alsoRemove
+    removeSkills = alsoRemove.data
+  }
+
+  if (removeSkills) {
+    // Cleanup runs first so a failed or partially completed upstream removal cannot also erase the
+    // set definition needed to understand and retry the operation.
+    const invocation = buildRemoveInvocation(removable)
+    ctx.ui.out(ctx.ui.style('dim', `running: ${formatInvocation(invocation, ctx.passthrough)}`))
+    const invocationArgs = ctx.passthrough.length === 0 ? invocation.args : [...invocation.args, ...ctx.passthrough]
+    // Set definitions live inside the skills dir; every upstream spawn is bracketed so they survive.
+    const guard = snapshotSetsDir(ctx.cwd)
+    const run = await (ctx.runner ?? runCommand)(invocation.command, invocationArgs, {
+      cwd: ctx.cwd,
+      env: invocation.env,
+      capture: ctx.ui.json,
+    })
+    if (restoreSetsDir(ctx.cwd, guard)) ctx.ui.out(ctx.ui.style('yellow', SETS_DIR_RESTORED_NOTICE))
+    if (!run.ok) {
+      return {
+        ok: false,
+        error: new SkillSetError(
+          run.error.code,
+          `Removing skills failed before the set was removed: ${run.error.message}. The set ${JSON.stringify(name)} remains installed, but skill cleanup may have partially completed.`,
+          {
+            hint: 'Inspect the installed skills, then retry removal. The set definition is still available as the source of truth.',
+            data: { name, attemptedSkills: removable, setRemoved: false, possiblePartialCleanup: true },
+            cause: run.error,
+          },
+        ),
+      }
+    }
+    if (run.data.exitCode !== 0) {
+      return {
+        ok: false,
+        error: new SkillSetError(
+          ErrorCodes.RESOLVE_FAILED,
+          `Removing skills failed: the skills CLI exited with code ${run.data.exitCode}. The set ${JSON.stringify(name)} remains installed, but skill cleanup may have partially completed.`,
+          {
+            hint: ctx.ui.json
+              ? 'Inspect data.stderr and the installed skills, then retry removal; the set definition remains available.'
+              : 'Inspect the skills output and installed skills, then retry removal; the set definition remains available.',
+            data: {
+              name,
+              attemptedSkills: removable,
+              exitCode: run.data.exitCode,
+              setRemoved: false,
+              possiblePartialCleanup: true,
+              ...(ctx.ui.json ? { stderr: run.data.stderr.slice(-2000) } : {}),
+            },
+          },
+        ),
+      }
+    }
+
+    ctx.ui.out(ctx.ui.style('dim', `  removed skills: ${removable.join(', ')}`))
+  }
+
+  // Only after all selected cleanup succeeds may the set artifacts and index be mutated.
   const paths = setPaths(ctx.cwd, name)
   rmSync(paths.manifest, { force: true })
   rmSync(paths.lock, { force: true })
@@ -69,51 +130,28 @@ export async function cmdRemove(args: string[], ctx: CommandContext): Promise<Co
   if (!index.ok) return index
   ctx.ui.out(`${ctx.ui.style('green', '✓')} Skill-set ${JSON.stringify(name)} (from ${source}) was successfully removed`)
 
-  // With this set gone, count its member skills against the sets that remain.
-  const counted = referenceCount(ctx, name, manifest.data.skills)
-  if (!counted.ok) return counted
-  const { removable, kept: skillsKept } = counted.data
-  for (const kept of skillsKept) ctx.ui.out(ctx.ui.style('dim', `  kept ${kept.skill ?? kept.member}: ${kept.reason}`))
-  if (removable.length === 0) return { ok: true, data: { name, removed: true, skillsRemoved: [], skillsKept } }
+  return { ok: true, data: { name, removed: true, skillsRemoved: removeSkills ? removable : [], skillsKept } }
+}
 
-  // Prompt 2: a convenience offer, not a gate — silently declined when no prompt is possible.
-  const alsoRemove = await ctx.ui.confirm(`Also remove its skills (${removable.join(', ')})?`, { optional: true })
-  if (!alsoRemove.ok) return alsoRemove
-  if (!alsoRemove.data) return { ok: true, data: { name, removed: true, skillsRemoved: [], skillsKept } }
-
-  // Delegated to the upstream CLI so skills-lock.json stays consistent with the folders.
-  const invocation = buildRemoveInvocation(removable)
-  ctx.ui.out(ctx.ui.style('dim', `running: ${formatInvocation(invocation, ctx.passthrough)}`))
-  const invocationArgs = ctx.passthrough.length === 0 ? invocation.args : [...invocation.args, ...ctx.passthrough]
-  // Set definitions live inside the skills dir; every upstream spawn is bracketed so they survive.
-  const guard = snapshotSetsDir(ctx.cwd)
-  const run = await (ctx.runner ?? runCommand)(invocation.command, invocationArgs, {
-    cwd: ctx.cwd,
-    env: invocation.env,
-    capture: ctx.ui.json,
-  })
-  if (restoreSetsDir(ctx.cwd, guard)) ctx.ui.out(ctx.ui.style('yellow', SETS_DIR_RESTORED_NOTICE))
-  if (!run.ok) return run
-  if (run.data.exitCode !== 0) {
-    return {
-      ok: false,
-      error: new SkillSetError(
-        ErrorCodes.RESOLVE_FAILED,
-        `Removing skills failed: the skills CLI exited with code ${run.data.exitCode}. The set ${JSON.stringify(name)} was already removed. Skill files were left in place.`,
-        {
-          hint: ctx.ui.json ? 'The captured skills output is in data.stderr.' : 'See the skills output above for the cause.',
-          data: {
-            name,
-            exitCode: run.data.exitCode,
-            ...(ctx.ui.json ? { stderr: run.data.stderr.slice(-2000) } : {}),
-          },
-        },
-      ),
-    }
+/** Prints the same complete, reference-counted plan for both real and dry-run removal. */
+function printRemovalPlan(
+  ctx: CommandContext,
+  name: string,
+  source: string,
+  removable: readonly string[],
+  kept: readonly KeptSkill[],
+): void {
+  ctx.ui.out(`Removal plan for ${JSON.stringify(name)} (from ${source}):`)
+  ctx.ui.out('  remove set: definition, lock, and generated files')
+  if (removable.length > 0) {
+    ctx.ui.out(`  optionally remove unshared skills: ${removable.join(', ')}`)
+    ctx.ui.out(
+      ctx.ui.style('dim', `    cleanup command on approval: ${formatInvocation(buildRemoveInvocation(removable), ctx.passthrough)}`),
+    )
+  } else {
+    ctx.ui.out(ctx.ui.style('dim', '  no unshared skills are eligible for removal'))
   }
-
-  ctx.ui.out(ctx.ui.style('dim', `  removed skills: ${removable.join(', ')}`))
-  return { ok: true, data: { name, removed: true, skillsRemoved: removable, skillsKept } }
+  for (const skill of kept) ctx.ui.out(ctx.ui.style('dim', `  kept ${skill.skill ?? skill.member}: ${skill.reason}`))
 }
 
 /**

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -17,12 +17,15 @@ export async function cmdUpdate(args: string[], ctx: CommandContext): Promise<Co
   if (!manifest.ok) return manifest
 
   // Every member must be locatable before anything updates — aggregate what is not.
+  const members: Array<{ locator: string; skill: string }> = []
   const skills = new Set<string>()
   const problems: string[] = []
   for (const locator of manifest.data.skills) {
     const located = locateMember(locator, { cwd: ctx.cwd })
-    if (located.ok) skills.add(located.data.skill)
-    else problems.push(`${locator}: ${located.error.message}`)
+    if (located.ok) {
+      members.push({ locator, skill: located.data.skill })
+      skills.add(located.data.skill)
+    } else problems.push(`${locator}: ${located.error.message}`)
   }
   if (problems.length > 0) {
     return {
@@ -36,13 +39,25 @@ export async function cmdUpdate(args: string[], ctx: CommandContext): Promise<Co
   }
 
   const names = [...skills]
-  ctx.ui.out(`Updating skill-set ${JSON.stringify(name)} — ${plural(names.length, 'skill')} with npx skills: ${names.join(', ')}`)
   const invocation = buildUpdateInvocation(names)
+  ctx.ui.out(`Update plan for skill-set ${JSON.stringify(name)} — ${plural(names.length, 'skill')} with npx skills:`)
+  for (const member of members) ctx.ui.out(`  ${member.locator} → ${member.skill}`)
   if (ctx.dryRun) {
     ctx.ui.out(ctx.ui.style('dim', `would run: ${formatInvocation(invocation, ctx.passthrough)}`))
     ctx.ui.out(`${ctx.ui.style('green', '✓')} dry run — no skills updated, no files changed`)
-    return { ok: true, data: { name, dryRun: true, wouldUpdate: names } }
+    return { ok: true, data: { name, dryRun: true, wouldUpdate: names, members } }
   }
+
+  ctx.ui.out(ctx.ui.style('yellow', `mutation boundary: ${formatInvocation(invocation, ctx.passthrough)}`))
+  if (!ctx.ui.json && ctx.ui.interactive && !ctx.ui.yes) {
+    const confirmed = await ctx.ui.confirm('Run this update command now?')
+    if (!confirmed.ok) return confirmed
+    if (!confirmed.data) {
+      ctx.ui.out('Aborted — no skills updated, no files changed.')
+      return { ok: true, data: { name, updated: false } }
+    }
+  }
+
   ctx.ui.out(ctx.ui.style('dim', `running: ${formatInvocation(invocation, ctx.passthrough)}`))
   const invocationArgs = ctx.passthrough.length === 0 ? invocation.args : [...invocation.args, ...ctx.passthrough]
   // Set definitions live inside the skills dir; every upstream spawn is bracketed so they survive.

--- a/packages/cli/test/cli-commands.test.ts
+++ b/packages/cli/test/cli-commands.test.ts
@@ -216,8 +216,11 @@ describe('authoring round-trip: init → install → lock → build → verify �
 
   it('update delegates to the pinned upstream and re-locks', async () => {
     const before = parseSetLock(readFileSync(join(setDir, 'my-tools.skill-set.lock.json'), 'utf8'))
-    const { code } = await cli(cwd, fake, ['update', 'my-tools'])
+    const { code, out } = await cli(cwd, fake, ['update', 'my-tools'])
     expect(code).toBe(0)
+    expect(out).toContain('hcjmartin/alpha-repo@alpha → alpha')
+    expect(out).toContain('hcjmartin/beta-repo → beta-repo')
+    expect(out).toContain('mutation boundary: npx -y skills@1.5.14 update alpha beta-repo -p --yes')
     expect(fake.calls.at(-1)).toEqual(['npx', '-y', 'skills@1.5.14', 'update', 'alpha', 'beta-repo', '-p', '--yes'])
     const after = parseSetLock(readFileSync(join(setDir, 'my-tools.skill-set.lock.json'), 'utf8'))
     expect(before.ok && after.ok && before.data.setHash !== after.data.setHash).toBe(true)
@@ -245,6 +248,83 @@ describe('authoring round-trip: init → install → lock → build → verify �
     expect(out.trimStart().startsWith('{')).toBe(false)
     expect(otherFake.calls[0]).toEqual([
       'npx', '-y', 'skills@1.5.14', 'add', 'hcjmartin/y-repo', '--skill', 'y', '--yes', '--json', '--help',
+    ])
+  })
+})
+
+describe('update confirmation', () => {
+  async function prepare(cwd: string, fake: FakeSkills): Promise<void> {
+    await cli(cwd, fake, ['init', 'u', 'hcjmartin/alpha-repo@alpha', '--yes'])
+    await cli(cwd, fake, ['lock', 'u'])
+  }
+
+  it('interactive decline stops at the displayed mutation boundary without spawning or changing files', async () => {
+    const cwd = project()
+    const fake = fakeSkills(cwd)
+    await prepare(cwd, fake)
+    const skillPath = join(cwd, SKILLS_DIR, 'alpha', 'SKILL.md')
+    const lockPath = join(cwd, SETS_DIR, 'u', 'u.skill-set.lock.json')
+    const skillBefore = readFileSync(skillPath, 'utf8')
+    const lockBefore = readFileSync(lockPath, 'utf8')
+    const spawnsBefore = fake.calls.length
+
+    const { code, out } = await cli(cwd, fake, ['update', 'u'], { interactive: true, confirmAnswers: [false] })
+
+    expect(code).toBe(0)
+    expect(out).toContain('Update plan for skill-set "u"')
+    expect(out).toContain('hcjmartin/alpha-repo@alpha → alpha')
+    expect(out).toContain('mutation boundary: npx -y skills@1.5.14 update alpha -p --yes')
+    expect(out).toContain('Aborted — no skills updated, no files changed.')
+    expect(fake.calls).toHaveLength(spawnsBefore)
+    expect(readFileSync(skillPath, 'utf8')).toBe(skillBefore)
+    expect(readFileSync(lockPath, 'utf8')).toBe(lockBefore)
+  })
+
+  it('interactive acceptance invokes the existing update flow', async () => {
+    const cwd = project()
+    const fake = fakeSkills(cwd)
+    await prepare(cwd, fake)
+    const spawnsBefore = fake.calls.length
+
+    const { code } = await cli(cwd, fake, ['update', 'u'], { interactive: true, confirmAnswers: [true] })
+
+    expect(code).toBe(0)
+    expect(fake.calls.slice(spawnsBefore)).toEqual([
+      ['npx', '-y', 'skills@1.5.14', 'update', 'alpha', '-p', '--yes'],
+    ])
+  })
+
+  it('--yes bypasses an interactive decline answer', async () => {
+    const cwd = project()
+    const fake = fakeSkills(cwd)
+    await prepare(cwd, fake)
+    const spawnsBefore = fake.calls.length
+
+    const { code } = await cli(cwd, fake, ['update', 'u', '--yes'], {
+      interactive: true,
+      confirmAnswers: [false],
+    })
+
+    expect(code).toBe(0)
+    expect(fake.calls.slice(spawnsBefore)).toEqual([
+      ['npx', '-y', 'skills@1.5.14', 'update', 'alpha', '-p', '--yes'],
+    ])
+  })
+
+  it('--json preserves non-interactive execution and returns one structured result', async () => {
+    const cwd = project()
+    const fake = fakeSkills(cwd)
+    await prepare(cwd, fake)
+    const spawnsBefore = fake.calls.length
+
+    // JSON remains prompt-free even when the underlying terminal is interactive.
+    const { code, out } = await cli(cwd, fake, ['update', 'u', '--json'], { interactive: true })
+
+    expect(code).toBe(0)
+    const envelope = JSON.parse(out) as { ok: boolean; command: string; data: { updated: string[] } }
+    expect(envelope).toMatchObject({ ok: true, command: 'update', data: { updated: ['alpha'] } })
+    expect(fake.calls.slice(spawnsBefore)).toEqual([
+      ['npx', '-y', 'skills@1.5.14', 'update', 'alpha', '-p', '--yes'],
     ])
   })
 })
@@ -1300,6 +1380,7 @@ describe('--dry-run', () => {
     const spawnsBefore = fake.calls.length
     const { code, out } = await cli(cwd, fake, ['update', 'd', '--dry-run'])
     expect(code).toBe(0)
+    expect(out).toContain('hcjmartin/alpha-repo@alpha → alpha')
     expect(out).toContain('would run: npx -y skills@1.5.14 update alpha -p --yes')
     expect(fake.calls.length).toBe(spawnsBefore)
   })

--- a/packages/cli/test/cli-commands.test.ts
+++ b/packages/cli/test/cli-commands.test.ts
@@ -307,14 +307,23 @@ describe('remove', () => {
     expect(Object.keys(index.sets)).toEqual(['two'])
   })
 
-  it('scripted yes/yes removes the set with its source, then delegates its unshared skill', async () => {
+  it('scripted yes/yes cleans up unshared skills while the confirmed set is still present, then removes it', async () => {
     const cwd = project()
     const fake = fakeSkills(cwd)
     await cli(cwd, fake, ['add', url, '--yes'], { fetcher })
+    const manifestPath = join(cwd, SETS_DIR, 'kit', 'kit.skill-set.json')
+    let setPresentDuringCleanup = false
+    const runner: CommandRunner = async (command, args, opts) => {
+      if (args[2] === 'remove') setPresentDuringCleanup = existsSync(manifestPath)
+      return fake.runner(command, args, opts)
+    }
     const spawnsBefore = fake.calls.length
-    const { code, out } = await cli(cwd, fake, ['remove', 'kit'], { confirmAnswers: [true, true] })
+    const { code, out } = await cli(cwd, { ...fake, runner }, ['remove', 'kit'], { confirmAnswers: [true, true] })
     expect(code).toBe(0)
+    expect(setPresentDuringCleanup).toBe(true)
     expect(existsSync(join(cwd, SETS_DIR, 'kit'))).toBe(false)
+    expect(out).toContain(`Removal plan for "kit" (from ${url}):`)
+    expect(out).toContain('optionally remove unshared skills: gamma')
     expect(out).toContain(`Skill-set "kit" (from ${url}) was successfully removed`)
     expect(existsSync(join(cwd, SKILLS_DIR, 'gamma'))).toBe(false)
     const removeCall = fake.calls.slice(spawnsBefore).find((c) => c[3] === 'remove')
@@ -332,6 +341,30 @@ describe('remove', () => {
     expect(out).toContain(`Skill-set "kit" (from ${url}) was successfully removed`)
     expect(existsSync(join(cwd, SKILLS_DIR, 'gamma'))).toBe(true)
     expect(fake.calls.slice(spawnsBefore).some((c) => c[3] === 'remove')).toBe(false)
+  })
+
+  it('upstream cleanup failure preserves the set and reports that skill cleanup may be partial', async () => {
+    const cwd = project()
+    const fake = fakeSkills(cwd)
+    await cli(cwd, fake, ['add', url, '--yes'], { fetcher })
+    const manifestPath = join(cwd, SETS_DIR, 'kit', 'kit.skill-set.json')
+    const runner: CommandRunner = async (command, args, opts) => {
+      const result = await fake.runner(command, args, opts)
+      return args[2] === 'remove'
+        ? { ok: true, data: { exitCode: 7, stdout: '', stderr: 'cleanup failed' } }
+        : result
+    }
+
+    const { code, err } = await cli(cwd, { ...fake, runner }, ['remove', 'kit'], { confirmAnswers: [true, true] })
+    expect(code).toBe(1)
+    expect(err).toContain('remains installed')
+    expect(err).toContain('skill cleanup may have partially completed')
+    expect(existsSync(manifestPath)).toBe(true)
+    // The fake upstream did remove this folder before reporting failure, demonstrating why the
+    // error cannot promise that skills were left untouched.
+    expect(existsSync(join(cwd, SKILLS_DIR, 'gamma'))).toBe(false)
+    const index = JSON.parse(readFileSync(join(cwd, SETS_DIR, INDEX_FILENAME), 'utf8')) as { sets: Record<string, unknown> }
+    expect(Object.keys(index.sets)).toContain('kit')
   })
 
   it('declining the first prompt leaves the set and its skills in place', async () => {
@@ -1250,9 +1283,10 @@ describe('--dry-run', () => {
 
     const dryRemove = await cli(cwd, fake, ['remove', 'd', '--dry-run'])
     expect(dryRemove.code).toBe(0)
-    // The preview mirrors the real flow: origin in the removal line, skill removal as an offer.
-    expect(dryRemove.out).toContain('would remove: set "d" (from .agents/skills/skill-sets/d/d.skill-set.json)')
-    expect(dryRemove.out).toContain('would offer to also remove its skills (alpha)')
+    // The preview reuses the complete plan shown by the real flow.
+    expect(dryRemove.out).toContain('Removal plan for "d" (from .agents/skills/skill-sets/d/d.skill-set.json)')
+    expect(dryRemove.out).toContain('remove set: definition, lock, and generated files')
+    expect(dryRemove.out).toContain('optionally remove unshared skills: alpha')
     expect(existsSync(join(cwd, SETS_DIR, 'd'))).toBe(true)
     expect(existsSync(join(cwd, SKILLS_DIR, 'alpha'))).toBe(true)
   })

--- a/packages/site/src/pages/cli.md
+++ b/packages/site/src/pages/cli.md
@@ -103,7 +103,7 @@ When a set has no lock, verify falls back to checking that every member is prese
 skill-set update <set>
 ```
 
-Updates every member through `npx skills@1.5.14 update <skills...> -p --yes`, then re-locks the set if a lock existed and regenerates the derived files. All members must be installed before anything updates.
+Prints the update plan (each locator and its skill) and the exact upstream invocation, then asks one confirmation before mutating; `--yes` and `--json` skip the prompt, `--dry-run` shows the plan and spawns nothing. Updates run through `npx skills@1.5.14 update <skills...> -p --yes`, then the set is re-locked if a lock existed and derived files regenerate. All members must be installed before anything updates.
 
 ### remove
 
@@ -111,7 +111,7 @@ Updates every member through `npx skills@1.5.14 update <skills...> -p --yes`, th
 skill-set remove <set>
 ```
 
-Removes the set definition — manifest, lock, and generated page — after confirmation, and refreshes the index. It then offers to also remove the set's member skills, keeping any skill still referenced by another set (reference-counted, including by shared source). Skill removal is delegated to `npx skills remove` so the upstream lock stays consistent.
+Prints the full removal plan up front (set artifacts, removable and kept skills, the upstream cleanup command) and collects both confirmations before anything mutates. Skills still referenced by another set are kept (reference-counted, including by shared source). Accepted skill cleanup is delegated to `npx skills remove` and runs before the set definition is deleted, so a failed cleanup leaves the set installed for a retry. Declining cleanup removes only the set definition (manifest, lock, generated page) and refreshes the index.
 
 ## Global flags
 


### PR DESCRIPTION
Closes #6, closes #7.

## Changes (`@skill-set/cli`, minor changeset)

- **#6 — failure-safe removal**: `remove` reference-counts and prints the full removal plan up front (set artifacts, removable and kept skills, the exact upstream cleanup command) and collects both confirmations before anything mutates. Accepted skill cleanup runs through `npx skills remove` *before* the set definition is deleted; a spawn failure or non-zero exit leaves the set installed with a structured error (`possiblePartialCleanup: true`) and a retry hint. Declining cleanup removes only the set, as before.
- **#7 — update confirmation**: `update` prints the update plan (each locator and its skill) and highlights the upstream invocation as the mutation boundary, then asks one confirmation before spawning. Declining exits `0` with `{ updated: false }` and no spawn. `--yes`, `--json`, and non-interactive runs are unaffected; `--dry-run` now lists the members while spawning nothing.

## Docs

`cli.md` `remove` and `update` sections updated to match the new order and confirmation flow.

## Merge with main

Includes a clean merge of current main (verify redesign #22, 0.3.0 #23) — no conflicts, no semantic overlap (main didn't touch `remove.ts`/`update.ts`).

## Tests

365 passed on the merged tree: interactive decline (no spawn, no file change), accept, `--yes` bypass, `--json` non-interactive, cleanup-before-delete ordering, and upstream-cleanup-failure preserving the set. `NODE_OPTIONS= pnpm run check` green.