### PR TITLE
ADD: @skill-set/core package. MOD: CLI hashing delegates to core; spec golden hash vectors.

### DIFF
--- a/.changeset/cli-delegate-hashing.md
+++ b/.changeset/cli-delegate-hashing.md
@@ -1,0 +1,5 @@
+---
+'@skill-set/cli': patch
+---
+
+Hashing now delegates its canonical framing to `@skill-set/core`; the CLI keeps the filesystem adapter and a synchronous `node:crypto` digest. No behavior change — outputs are byte-identical, cross-checked in tests.

--- a/.changeset/core-initial-release.md
+++ b/.changeset/core-initial-release.md
@@ -1,0 +1,5 @@
+---
+'@skill-set/core': minor
+---
+
+Initial release: runtime-agnostic spec primitives for server-side and non-CLI implementations. Exports the spec hash recipes as bytes-in functions (`specFolderHash`, `setHash`, `skillMarkdownFolderHash`, plus the skills-ecosystem interop `compatFolderHash`) digested via WebCrypto, the canonical framing functions (`folderHashInput`, `setHashInput`, `compatFolderHashInput`) for synchronous or streaming hashers, the spec algorithm identifiers (`skill-set/folder-v1`, `skill-set/set-v1`), and typed lock-file shapes (`SkillSetLock`, `SkillSetLockMember`). Zero dependencies; runs on Node ≥20, Cloudflare Workers, Deno, Bun, and browsers. The test suite is pinned to the spec's new golden hash vectors.

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ More at [skill-set.md/faq](https://skill-set.md/faq/).
 - [skill-set.md](https://skill-set.md) — docs site: CLI reference, FAQ, and the rendered spec
 - [The format spec (draft)](spec/draft/README.md) — normative convention for the `<name>.skill-set.json` manifest: fields, validation rules, sharing semantics, the lock format, and the content-hash recipe, written so a set can be authored, resolved, and verified without this CLI
 - [JSON Schemas](spec/draft) — `skill-set.schema.json` and `skill-set.lock.schema.json`
+- [`@skill-set/core`](packages/core) — runtime-agnostic spec primitives (hashes, algorithm identifiers, lock types) for server-side and non-CLI implementations; pinned to the spec's [golden hash vectors](spec/draft/examples/hash)
 - [skill-sets.md](https://skill-sets.md) — a directory of shareable sets
 
 ## Naming

--- a/packages/cli/src/hash.ts
+++ b/packages/cli/src/hash.ts
@@ -1,13 +1,20 @@
 import { createHash } from 'node:crypto'
 import { lstatSync, readdirSync, readFileSync } from 'node:fs'
 import { join, relative } from 'node:path'
+import {
+  compatFolderHashInput,
+  folderHashInput,
+  setHashInput,
+  type SkillFile,
+} from '@skill-set/core'
 
-type FileEntry = { rel: string; bytes: Buffer }
+// Canonical framing lives in @skill-set/core; this module is the filesystem
+// adapter (enumeration per spec §6.1) plus a synchronous node:crypto digest.
 
 const SKIPPED_DIRS = new Set(['.git', 'node_modules'])
 
-function collectFiles(dir: string, base: string): FileEntry[] {
-  const out: FileEntry[] = []
+function collectFiles(dir: string, base: string): SkillFile[] {
+  const out: SkillFile[] = []
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
     const full = join(dir, entry.name)
     // Some filesystems (FUSE/NFS) report unknown dirent types; classify those via lstat.
@@ -18,25 +25,21 @@ function collectFiles(dir: string, base: string): FileEntry[] {
       if (SKIPPED_DIRS.has(entry.name)) continue
       out.push(...collectFiles(full, base))
     } else if (kind.isFile()) {
-      out.push({ rel: relative(base, full).split('\\').join('/'), bytes: readFileSync(full) })
+      out.push({ path: relative(base, full).split('\\').join('/'), bytes: readFileSync(full) })
     }
   }
   return out
 }
 
-/** The normative spec hash (spec §6): NFC paths, UTF-8-byte-order sort, NUL framing, locale-independent. */
-export function specFolderHash(dir: string): string {
-  // NFC per spec §6 — APFS reports decomposed (NFD) filenames, Linux stores them as written.
-  const files = collectFiles(dir, dir).map((f) => ({ ...f, rel: f.rel.normalize('NFC') }))
-  files.sort((a, b) => Buffer.compare(Buffer.from(a.rel, 'utf8'), Buffer.from(b.rel, 'utf8')))
+function digest(chunks: Uint8Array[]): string {
   const hash = createHash('sha256')
-  for (const f of files) {
-    hash.update(f.rel, 'utf8')
-    hash.update(Buffer.from([0]))
-    hash.update(f.bytes)
-    hash.update(Buffer.from([0]))
-  }
+  for (const chunk of chunks) hash.update(chunk)
   return hash.digest('hex')
+}
+
+/** The normative spec hash (spec §6, `skill-set/folder-v1`): NFC paths, UTF-8-byte-order sort, NUL framing. */
+export function specFolderHash(dir: string): string {
+  return digest(folderHashInput(collectFiles(dir, dir)))
 }
 
 /**
@@ -47,24 +50,10 @@ export function specFolderHash(dir: string): string {
  * server-side snapshot hash instead, which no local bytes reproduce (see test/compat.test.ts).
  */
 export function compatFolderHash(dir: string): string {
-  const files = collectFiles(dir, dir)
-  files.sort((a, b) => a.rel.localeCompare(b.rel))
-  const hash = createHash('sha256')
-  for (const f of files) {
-    hash.update(f.rel)
-    hash.update(f.bytes)
-  }
-  return hash.digest('hex')
+  return digest(compatFolderHashInput(collectFiles(dir, dir)))
 }
 
-/** The set-lock rollup (spec §5): sorted locators, `<locator>\n<computedHash>\n` per member. */
+/** The set-lock rollup (spec §5, `skill-set/set-v1`): sorted locators, `<locator>\n<computedHash>\n` per member. */
 export function setHash(members: Record<string, string>): string {
-  const locators = Object.keys(members).sort((a, b) =>
-    Buffer.compare(Buffer.from(a, 'utf8'), Buffer.from(b, 'utf8')),
-  )
-  const hash = createHash('sha256')
-  for (const locator of locators) {
-    hash.update(`${locator}\n${members[locator]}\n`, 'utf8')
-  }
-  return hash.digest('hex')
+  return digest(setHashInput(members))
 }

--- a/packages/cli/test/hash.test.ts
+++ b/packages/cli/test/hash.test.ts
@@ -3,6 +3,11 @@ import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
+import {
+  compatFolderHash as coreCompatFolderHash,
+  setHash as coreSetHash,
+  specFolderHash as coreSpecFolderHash,
+} from '@skill-set/core'
 import { compatFolderHash, setHash, specFolderHash } from '../src/hash.ts'
 
 // Expected digests computed independently with `printf | shasum -a 256`, not with this code.
@@ -212,5 +217,28 @@ describe('setHash', () => {
     const expected = createHash('sha256')
     for (const k of keys) expected.update(`${k}\n${members[k]}\n`, 'utf8')
     expect(setHash(members)).toBe(expected.digest('hex'))
+  })
+})
+
+describe('cross-check against @skill-set/core', () => {
+  it('agrees byte-for-byte with core across all three recipes', async () => {
+    // The CLI is core's framing plus a filesystem adapter and a sync digest — the
+    // outputs must be indistinguishable from core's async WebCrypto path.
+    const files: Record<string, string | Uint8Array> = {
+      'SKILL.md': '---\nname: probe\n---\nBody.\n',
+      'B.txt': 'big\n',
+      'a.txt': 'small\n',
+      'sub/blob.bin': Uint8Array.from([0x00, 0x01, 0xff, 0x80]),
+    }
+    const dir = tmpFolder(files)
+    const encoder = new TextEncoder()
+    const asSkillFiles = Object.entries(files).map(([path, content]) => ({
+      path,
+      bytes: typeof content === 'string' ? encoder.encode(content) : content,
+    }))
+    expect(specFolderHash(dir)).toBe(await coreSpecFolderHash(asSkillFiles))
+    expect(compatFolderHash(dir)).toBe(await coreCompatFolderHash(asSkillFiles))
+    const members = { beta: 'b'.repeat(64), alpha: 'a'.repeat(64) }
+    expect(setHash(members)).toBe(await coreSetHash(members))
   })
 })

--- a/packages/core/LICENSE
+++ b/packages/core/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Harry Martin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,55 @@
+# @skill-set/core
+
+Runtime-agnostic primitives for the [skill-set format](https://github.com/hcjmartin/skill-set/blob/main/spec/draft/README.md): the spec's content hashes, their algorithm identifiers, and lock-file types.
+
+Built for implementations the [`@skill-set/cli`](https://www.npmjs.com/package/@skill-set/cli) can't serve — servers, edge runtimes, registries — so they don't have to port the spec recipes by hand. Inputs are `(path, bytes)` pairs rather than directories, and digests use WebCrypto, so the same code runs on Node ≥20, Cloudflare Workers, Deno, Bun, and browsers. Zero dependencies.
+
+```sh
+npm install @skill-set/core
+```
+
+## Usage
+
+```ts
+import {
+  FOLDER_HASH_ALGORITHM, // 'skill-set/folder-v1'
+  SET_HASH_ALGORITHM,    // 'skill-set/set-v1'
+  specFolderHash,
+  skillMarkdownFolderHash,
+  setHash,
+  type SkillSetLock,
+} from '@skill-set/core'
+
+// Member content hash (spec §6) over in-memory file bytes — e.g. an upload or DB row.
+const computedHash = await specFolderHash([
+  { path: 'SKILL.md', bytes: skillMd },
+  { path: 'reference/notes.md', bytes: notes },
+])
+
+// The common single-file case.
+const hash = await skillMarkdownFolderHash(markdown)
+
+// Set-lock rollup (spec §5) — directly comparable to a `.skill-set.lock.json`.
+const lock: SkillSetLock = JSON.parse(lockJson)
+const verified = (await setHash(
+  Object.fromEntries(Object.entries(lock.skills).map(([loc, m]) => [loc, m.computedHash])),
+)) === lock.setHash
+```
+
+Hashes are byte-identical to the reference CLI's and to any conforming implementation — the recipes are locale-independent by construction (NFC paths, UTF-8-byte-order sort, NUL framing), and this package's test suite is pinned to the spec's [golden vectors](https://github.com/hcjmartin/skill-set/tree/main/spec/draft/examples/hash).
+
+## API
+
+| Export | What it is |
+| --- | --- |
+| `specFolderHash(files)` | Member content hash (spec §6), lowercase hex. `files` is `{ path, bytes }[]`; enumeration (skipping `.git`/`node_modules`/symlinks) is the caller's platform-specific part. |
+| `skillMarkdownFolderHash(content)` | Folder hash of a lone `SKILL.md` — the common authoring case. |
+| `setHash(members)` | Set-lock rollup (spec §5) over `{ locator: computedHash }`. |
+| `folderHashInput(files)` / `setHashInput(members)` | The exact canonical byte sequences the recipes digest, for synchronous or streaming hashers (the CLI feeds these to `node:crypto`). |
+| `FOLDER_HASH_ALGORITHM` / `SET_HASH_ALGORITHM` | The spec's algorithm identifiers, for storing or transmitting digests with provenance. |
+| `SkillSetLock` / `SkillSetLockMember` | Typed shape of `<name>.skill-set.lock.json` (types only — schema validation stays the reader's responsibility). |
+| `compatFolderHash(files)` / `compatFolderHashInput(files)` | **Not a spec algorithm.** Byte-compatible with `vercel-labs/skills` `computeSkillFolderHash` (v1.5.x), for `skills-lock.json` interop only; locale-sensitive by upstream design. |
+
+## License
+
+MIT

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,30 +1,32 @@
 {
-  "name": "@skill-set/cli",
-  "version": "0.4.0",
-  "description": "Define, share, and install named, versioned sets of agent skills.",
+  "name": "@skill-set/core",
+  "version": "0.0.0",
+  "description": "Runtime-agnostic primitives for the skill-set format: spec hashes, algorithm identifiers, and lock types.",
   "type": "module",
-  "bin": {
-    "skill-set": "bin/cli.mjs"
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
   },
   "files": [
-    "bin",
-    "dist",
-    "schema"
+    "dist"
   ],
+  "sideEffects": false,
   "keywords": [
     "agent",
     "skills",
     "agent-skills",
     "skill-set",
     "ai",
-    "cli"
+    "hash"
   ],
   "author": "Harry Martin <hcjmartin@gmail.com>",
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/hcjmartin/skill-set.git",
-    "directory": "packages/cli"
+    "directory": "packages/core"
   },
   "homepage": "https://skill-set.md",
   "engines": {
@@ -35,23 +37,12 @@
   },
   "scripts": {
     "build": "tsdown",
-    "prepack": "node scripts/sync-schemas.mjs",
     "dev": "tsdown --watch",
     "test": "vitest run",
-    "typecheck": "tsc --noEmit",
-    "test:coverage": "vitest run --coverage"
-  },
-  "dependencies": {
-    "@skill-set/core": "workspace:^",
-    "ci-info": "^4.4.0",
-    "tinyexec": "^1.2.4",
-    "zod": "^4.4.3"
+    "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
-    "@vitest/coverage-v8": "^4.1.9",
-    "ajv": "^8.17.1",
-    "ajv-formats": "^3.0.1",
     "tsdown": "^0.22.3",
     "typescript": "^6.0.3",
     "vitest": "^4.1.9"

--- a/packages/core/src/hash.ts
+++ b/packages/core/src/hash.ts
@@ -1,0 +1,98 @@
+/**
+ * The spec hash recipes (spec §5–§6): bytes in, lowercase hex out.
+ *
+ * Runtime-agnostic by construction — inputs are (path, bytes) pairs rather than
+ * a directory, and digests use WebCrypto — so the same code runs on Node ≥20,
+ * Cloudflare Workers, Deno, Bun, and browsers. Enumerating a real folder into
+ * pairs is the caller's platform-specific part (the reference CLI's filesystem
+ * adapter skips `.git`/`node_modules` dirs and symlinks per §6.1).
+ *
+ * The `*Input` functions expose the exact canonical byte sequence each recipe
+ * digests, for callers that need a synchronous or streaming hasher (the CLI
+ * feeds them to node:crypto); the async functions are those bytes through
+ * WebCrypto SHA-256.
+ */
+
+/** Names the §6 member content hash wherever a digest travels with provenance. */
+export const FOLDER_HASH_ALGORITHM = 'skill-set/folder-v1'
+/** Names the §5 setHash rollup wherever a digest travels with provenance. */
+export const SET_HASH_ALGORITHM = 'skill-set/set-v1'
+
+export interface SkillFile {
+  /** Path relative to the skill folder root, `/`-separated (any Unicode form; NFC is applied here). */
+  path: string
+  /** The file's raw bytes, exactly as stored. */
+  bytes: Uint8Array
+}
+
+const encoder = new TextEncoder()
+const NUL = Uint8Array.of(0)
+
+function compareBytes(a: Uint8Array, b: Uint8Array): number {
+  const len = Math.min(a.length, b.length)
+  for (let i = 0; i < len; i++) {
+    const diff = a[i]! - b[i]!
+    if (diff !== 0) return diff
+  }
+  return a.length - b.length
+}
+
+async function sha256Hex(chunks: Uint8Array[]): Promise<string> {
+  const total = chunks.reduce((sum, chunk) => sum + chunk.length, 0)
+  const bytes = new Uint8Array(total)
+  let offset = 0
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset)
+    offset += chunk.length
+  }
+  const digest = await crypto.subtle.digest('SHA-256', bytes)
+  return Array.from(new Uint8Array(digest), (b) => b.toString(16).padStart(2, '0')).join('')
+}
+
+/** The exact byte sequence §6 digests: NFC paths, UTF-8-byte-order sort, NUL framing. */
+export function folderHashInput(files: SkillFile[]): Uint8Array[] {
+  const entries = files.map((file) => ({
+    rel: encoder.encode(file.path.split('\\').join('/').normalize('NFC')),
+    bytes: file.bytes,
+  }))
+  entries.sort((a, b) => compareBytes(a.rel, b.rel))
+  return entries.flatMap((entry) => [entry.rel, NUL, entry.bytes, NUL])
+}
+
+/** The member content hash (spec §6, `skill-set/folder-v1`), lowercase hex. */
+export async function specFolderHash(files: SkillFile[]): Promise<string> {
+  return sha256Hex(folderHashInput(files))
+}
+
+/** Folder hash of a single-file SKILL.md skill — the common authoring case. */
+export async function skillMarkdownFolderHash(content: string): Promise<string> {
+  return specFolderHash([{ path: 'SKILL.md', bytes: encoder.encode(content) }])
+}
+
+/** The exact byte sequence §5 digests: `<locator>\n<computedHash>\n` in UTF-8-byte-order of the locator. */
+export function setHashInput(members: Record<string, string>): Uint8Array[] {
+  const locators = Object.keys(members)
+    .map((locator) => ({ locator, bytes: encoder.encode(locator) }))
+    .sort((a, b) => compareBytes(a.bytes, b.bytes))
+  return locators.map(({ locator }) => encoder.encode(`${locator}\n${members[locator]}\n`))
+}
+
+/** The set-lock rollup hash (spec §5, `skill-set/set-v1`), lowercase hex. */
+export async function setHash(members: Record<string, string>): Promise<string> {
+  return sha256Hex(setHashInput(members))
+}
+
+/**
+ * NOT a spec algorithm — the byte sequence vercel-labs/skills computeSkillFolderHash
+ * (v1.5.x) digests, for interoperating with `skills-lock.json` only. Locale-sensitive
+ * sort by upstream design; paths and bytes go in as given (no NFC, no framing).
+ */
+export function compatFolderHashInput(files: SkillFile[]): Uint8Array[] {
+  const entries = [...files].sort((a, b) => a.path.localeCompare(b.path))
+  return entries.flatMap((entry) => [encoder.encode(entry.path), entry.bytes])
+}
+
+/** The skills-ecosystem interop hash over `compatFolderHashInput`, lowercase hex. */
+export async function compatFolderHash(files: SkillFile[]): Promise<string> {
+  return sha256Hex(compatFolderHashInput(files))
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,0 +1,13 @@
+export {
+  FOLDER_HASH_ALGORITHM,
+  SET_HASH_ALGORITHM,
+  compatFolderHash,
+  compatFolderHashInput,
+  folderHashInput,
+  setHash,
+  setHashInput,
+  skillMarkdownFolderHash,
+  specFolderHash,
+  type SkillFile,
+} from './hash.ts'
+export type { SkillSetLock, SkillSetLockMember } from './lock.ts'

--- a/packages/core/src/lock.ts
+++ b/packages/core/src/lock.ts
@@ -1,0 +1,31 @@
+/**
+ * Typed shape of `<name>.skill-set.lock.json` (spec §5, lock format version 1).
+ * Mirrors skill-set.lock.schema.json; useful for consumers that already have
+ * parsed JSON and want types without a validation dependency. These types
+ * assert shape only — schema validation remains the reader's responsibility.
+ */
+
+/** Resolution record for one member skill, keyed in the lock by its manifest locator. */
+export interface SkillSetLockMember {
+  /** The installed skill name (directory name under the skills root). */
+  skill: string
+  /** Member content hash (spec §6, `skill-set/folder-v1`), lowercase hex. */
+  computedHash: string
+  /** Resolver-reported source kind (open vocabulary, e.g. `github`, `git`, `well-known`). */
+  sourceType?: string
+  /** Resolver-reported resolved ref (tag or branch), when the source has one. */
+  ref?: string
+}
+
+export interface SkillSetLock {
+  /** Lock format version; this shape describes version 1. */
+  version: 1
+  /** The set's name (equals the manifest name and the filename stem). */
+  name: string
+  /** The manifest version at lock time. */
+  setVersion: string
+  /** Rollup hash over the members (spec §5, `skill-set/set-v1`), lowercase hex. */
+  setHash: string
+  /** One entry per member, keyed by the manifest locator string. */
+  skills: Record<string, SkillSetLockMember>
+}

--- a/packages/core/test/hash.test.ts
+++ b/packages/core/test/hash.test.ts
@@ -1,0 +1,142 @@
+import { createHash } from 'node:crypto'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import {
+  FOLDER_HASH_ALGORITHM,
+  SET_HASH_ALGORITHM,
+  compatFolderHash,
+  folderHashInput,
+  setHash,
+  setHashInput,
+  skillMarkdownFolderHash,
+  specFolderHash,
+  type SkillFile,
+} from '../src/hash.ts'
+
+// The spec's golden vectors are the acceptance criteria (spec §8); this suite is
+// primarily vector-driven so core stays the reference implementation of them.
+const vectorsDir = join(import.meta.dirname, '..', '..', '..', 'spec', 'draft', 'examples', 'hash')
+
+interface FolderVector {
+  name: string
+  files: { path: string; contentUtf8?: string; contentBase64?: string }[]
+  expected: string
+}
+interface SetVector {
+  name: string
+  members: Record<string, string>
+  expected: string
+}
+
+function readVectors<T>(file: string): { algorithm: string; vectors: T[] } {
+  return JSON.parse(readFileSync(join(vectorsDir, file), 'utf8'))
+}
+
+function toSkillFiles(files: FolderVector['files']): SkillFile[] {
+  return files.map((f) => ({
+    path: f.path,
+    bytes:
+      f.contentBase64 !== undefined
+        ? new Uint8Array(Buffer.from(f.contentBase64, 'base64'))
+        : new TextEncoder().encode(f.contentUtf8),
+  }))
+}
+
+const folderSuite = readVectors<FolderVector>('folder-hash-vectors.json')
+const setSuite = readVectors<SetVector>('set-hash-vectors.json')
+
+describe('spec golden vectors', () => {
+  it('names the algorithms the vectors are recorded under', () => {
+    expect(folderSuite.algorithm).toBe(FOLDER_HASH_ALGORITHM)
+    expect(setSuite.algorithm).toBe(SET_HASH_ALGORITHM)
+    expect(FOLDER_HASH_ALGORITHM).toBe('skill-set/folder-v1')
+    expect(SET_HASH_ALGORITHM).toBe('skill-set/set-v1')
+  })
+
+  it.each(folderSuite.vectors)('folder: $name', async ({ files, expected }) => {
+    expect(await specFolderHash(toSkillFiles(files))).toBe(expected)
+    // Input order must not matter — only the sorted canonical order does.
+    expect(await specFolderHash(toSkillFiles(files).reverse())).toBe(expected)
+  })
+
+  it.each(setSuite.vectors)('set: $name', async ({ members, expected }) => {
+    expect(await setHash(members)).toBe(expected)
+  })
+})
+
+describe('specFolderHash', () => {
+  it('does not mutate the caller’s file array', async () => {
+    const files = toSkillFiles([
+      { path: 'b.txt', contentUtf8: 'beta\n' },
+      { path: 'a.txt', contentUtf8: 'alpha\n' },
+    ])
+    await specFolderHash(files)
+    expect(files.map((f) => f.path)).toEqual(['b.txt', 'a.txt'])
+  })
+
+  it('normalizes NFD and NFC path spellings to the same digest', async () => {
+    const bytes = new TextEncoder().encode('x\n')
+    const nfc = await specFolderHash([{ path: '\u00e9.txt', bytes }])
+    const nfd = await specFolderHash([{ path: 'e\u0301.txt', bytes }])
+    expect(nfd).toBe(nfc)
+  })
+
+  it('rewrites backslashes to "/", matching the reference adapters', async () => {
+    const bytes = new TextEncoder().encode('x\n')
+    expect(await specFolderHash([{ path: 'weird\\name.txt', bytes }])).toBe(
+      await specFolderHash([{ path: 'weird/name.txt', bytes }]),
+    )
+  })
+})
+
+describe('skillMarkdownFolderHash', () => {
+  it('equals the folder hash of a lone SKILL.md (the single-skill-md vector)', async () => {
+    const vector = folderSuite.vectors.find((v) => v.name === 'single-skill-md')!
+    expect(await skillMarkdownFolderHash(vector.files[0]!.contentUtf8!)).toBe(vector.expected)
+  })
+})
+
+describe('input framings', () => {
+  it('folderHashInput yields the exact §6 byte sequence (digestable synchronously)', async () => {
+    const files = toSkillFiles([
+      { path: 'a.txt', contentUtf8: 'alpha\n' },
+      { path: 'sub/c.txt', contentUtf8: 'gamma\n' },
+    ])
+    const sync = createHash('sha256')
+    for (const chunk of folderHashInput(files)) sync.update(chunk)
+    expect(sync.digest('hex')).toBe(await specFolderHash(files))
+  })
+
+  it('setHashInput yields the exact §5 byte sequence', async () => {
+    const members = { beta: 'b'.repeat(64), alpha: 'a'.repeat(64) }
+    const sync = createHash('sha256')
+    for (const chunk of setHashInput(members)) sync.update(chunk)
+    expect(sync.digest('hex')).toBe(await setHash(members))
+  })
+})
+
+describe('compatFolderHash (interop, not a spec algorithm)', () => {
+  it('matches an independently framed digest: locale sort, no NFC, no framing', async () => {
+    const files: SkillFile[] = [
+      { path: 'B.txt', bytes: new TextEncoder().encode('big\n') },
+      { path: 'a.txt', bytes: new TextEncoder().encode('small\n') },
+    ]
+    // Guard the collation assumption the expectation is framed under.
+    expect(['B.txt', 'a.txt'].sort((a, b) => a.localeCompare(b))).toEqual(['a.txt', 'B.txt'])
+    const expected = createHash('sha256')
+    expected.update('a.txt', 'utf8')
+    expected.update('small\n', 'utf8')
+    expected.update('B.txt', 'utf8')
+    expected.update('big\n', 'utf8')
+    expect(await compatFolderHash(files)).toBe(expected.digest('hex'))
+  })
+
+  it('diverges from the spec hash where locale and byte order disagree', async () => {
+    const files: SkillFile[] = [
+      { path: 'B.txt', bytes: new TextEncoder().encode('big\n') },
+      { path: 'a.txt', bytes: new TextEncoder().encode('small\n') },
+    ]
+    expect(await compatFolderHash(files)).not.toBe(await specFolderHash(files))
+  })
+})

--- a/packages/core/test/lock.test.ts
+++ b/packages/core/test/lock.test.ts
@@ -1,0 +1,44 @@
+import { readFileSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { setHash } from '../src/hash.ts'
+import type { SkillSetLock } from '../src/lock.ts'
+
+const fixturesDir = join(
+  import.meta.dirname,
+  '..',
+  '..',
+  '..',
+  'spec',
+  'draft',
+  'examples',
+  'lock',
+  'valid',
+)
+
+const fixtures = readdirSync(fixturesDir)
+  .filter((f) => f.endsWith('.skill-set.lock.json'))
+  .map((f) => ({ file: f, lock: JSON.parse(readFileSync(join(fixturesDir, f), 'utf8')) as SkillSetLock }))
+
+describe('SkillSetLock', () => {
+  it('covers every valid lock fixture', () => {
+    expect(fixtures.length).toBeGreaterThan(0)
+    for (const { lock } of fixtures) {
+      expect(lock.version).toBe(1)
+      expect(typeof lock.name).toBe('string')
+      expect(typeof lock.setVersion).toBe('string')
+      expect(lock.setHash).toMatch(/^[a-f0-9]{64}$/)
+      for (const member of Object.values(lock.skills)) {
+        expect(typeof member.skill).toBe('string')
+        expect(member.computedHash).toMatch(/^[a-f0-9]{64}$/)
+      }
+    }
+  })
+
+  it.each(fixtures)('reproduces the recorded setHash of $file', async ({ lock }) => {
+    const members = Object.fromEntries(
+      Object.entries(lock.skills).map(([locator, member]) => [locator, member.computedHash]),
+    )
+    expect(await setHash(members)).toBe(lock.setHash)
+  })
+})

--- a/packages/core/test/package-surface.test.ts
+++ b/packages/core/test/package-surface.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import pkg from '../package.json' with { type: 'json' }
+
+// The published surface is a single typed ESM entry with no runtime dependencies —
+// that zero-dep, runtime-agnostic shape is the package's contract; pin it.
+
+describe('package surface pins', () => {
+  it('ships a single typed ESM export and only built files', () => {
+    expect(pkg.name).toBe('@skill-set/core')
+    expect(pkg.type).toBe('module')
+    expect(pkg.exports).toEqual({
+      '.': { types: './dist/index.d.ts', import: './dist/index.js' },
+    })
+    expect(pkg.files).toEqual(['dist'])
+    expect(pkg.sideEffects).toBe(false)
+    expect(pkg.publishConfig).toEqual({ access: 'public' })
+  })
+
+  it('declares no runtime dependencies', () => {
+    expect('dependencies' in pkg).toBe(false)
+    expect('peerDependencies' in pkg).toBe(false)
+  })
+})

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src", "test", "tsdown.config.ts"]
+}

--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+  platform: 'neutral',
+  dts: true,
+  clean: true,
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
 
   packages/cli:
     dependencies:
+      '@skill-set/core':
+        specifier: workspace:^
+        version: link:../core
       ci-info:
         specifier: ^4.4.0
         version: 4.4.0
@@ -45,6 +48,21 @@ importers:
       ajv-formats:
         specifier: ^3.0.1
         version: 3.0.1(ajv@8.20.0)
+      tsdown:
+        specifier: ^0.22.3
+        version: 0.22.3(typescript@6.0.3)
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.9
+        version: 4.1.9(@types/node@22.20.0)(@vitest/coverage-v8@4.1.9)(vite@8.1.0(@types/node@22.20.0)(esbuild@0.28.1))
+
+  packages/core:
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.20.0
       tsdown:
         specifier: ^0.22.3
         version: 0.22.3(typescript@6.0.3)

--- a/spec/draft/README.md
+++ b/spec/draft/README.md
@@ -139,6 +139,17 @@ Per-member entry:
 >
 > Note: content bytes are hashed as stored on disk. Checkout-time filters that rewrite bytes (e.g. git `core.autocrlf` or `.gitattributes` text conversion) change the hash before any implementation runs; skill content that must verify across platforms should pin such filters off.
 
+### Algorithm identifiers
+
+Where a digest travels with provenance — a database column, an API field, an algorithm-prefixed out-of-band value (§3) — the recipes defined by this document are named:
+
+| Identifier | Recipe |
+|---|---|
+| `skill-set/folder-v1` | The member content hash, exactly as defined by this section. |
+| `skill-set/set-v1` | The `setHash` rollup, exactly as defined in §5. |
+
+An identifier pins the **entire** recipe — enumeration, normalization, ordering, framing, and digest algorithm. Any change to any of these is a new identifier, never a reinterpretation of an existing one. A consumer encountering an identifier it does not recognize MUST reject the value, not ignore or best-effort it.
+
 ## 7. Generated artifacts & determinism
 
 Everything an implementation generates from a manifest (the set-lock, any human-readable set summary, any index) MUST be deterministic: identical inputs produce identical bytes. For JSON artifacts, the required serialization is the output of ECMA-262 `JSON.stringify(value, null, 2)` — with object keys inserted in UTF-8-byte-order unless a field specifies otherwise — encoded as UTF-8 with LF line endings and a single trailing LF. No timestamps. Determinism is what makes locks merge-friendly and future signing possible.
@@ -150,6 +161,7 @@ The [`examples/`](./examples/) trees are the executable acceptance criteria:
 - every manifest under `examples/valid/` MUST validate against the schema and the §2 rules;
 - every manifest under `examples/invalid/` MUST fail schema validation for exactly the one violation recorded for it in `examples/invalid/violations.json` (the machine-readable form of "one reason per fixture");
 - every manifest under `examples/invalid-rules/` validates against the schema but MUST be rejected under the §2 rules;
-- the lock fixtures under `examples/lock/` follow the same valid/invalid contract against the lock schema.
+- the lock fixtures under `examples/lock/` follow the same valid/invalid contract against the lock schema;
+- every golden vector under [`examples/hash/`](./examples/hash/) MUST reproduce: hashing a folder vector's files per §6, or rolling up a set vector's members per §5, produces exactly the recorded digest.
 
 An independent implementation that agrees with every fixture verdict and reproduces §5–§6 hashes byte-for-byte is conforming.

--- a/spec/draft/examples/hash/README.md
+++ b/spec/draft/examples/hash/README.md
@@ -1,0 +1,19 @@
+# Hash vectors
+
+Golden vectors for the two hash recipes: [`folder-hash-vectors.json`](./folder-hash-vectors.json) for the member content hash (§6, `skill-set/folder-v1`) and [`set-hash-vectors.json`](./set-hash-vectors.json) for the `setHash` rollup (§5, `skill-set/set-v1`). A conforming implementation reproduces every `expected` digest exactly.
+
+The vectors are JSON, not on-disk folders, deliberately: checked-out fixture folders would not survive the round trip — filesystems disagree on filename normalization (APFS decomposes) and git filters can rewrite content bytes — which is exactly the class of divergence the recipes are designed to erase. The JSON gives each implementation identical `(path, bytes)` inputs; enumerating a real folder into such pairs is the platform-specific part left to the implementation.
+
+## Folder vector format
+
+Each vector lists a skill folder's files:
+
+- `path` — relative path, `/`-separated. Given as enumerated, which may be a non-NFC form (`nfd-path-normalizes-to-nfc` gives `e` + combining U+0301); the implementation normalizes to NFC per §6.2.
+- `contentUtf8` **or** `contentBase64` — exactly one. `contentUtf8` is the file's bytes as a UTF-8 string (escapes decoded, no newline translation); `contentBase64` is raw bytes, for content that is not valid UTF-8.
+- `expected` — the lowercase hex digest per §6.
+
+## Set vector format
+
+Each vector gives `members` (locator → `computedHash`) and the `expected` rollup per §5. Locators are hashed as given — no normalization applies to them.
+
+Failing `byte-order-not-locale-order` or `utf8-byte-sort-not-utf16` indicates sorting with locale collation or UTF-16 code units instead of UTF-8 bytes; failing `nfd-path-normalizes-to-nfc` indicates missing NFC path normalization.

--- a/spec/draft/examples/hash/folder-hash-vectors.json
+++ b/spec/draft/examples/hash/folder-hash-vectors.json
@@ -1,0 +1,63 @@
+{
+  "algorithm": "skill-set/folder-v1",
+  "description": "Golden vectors for the member content hash (spec §6). Each vector lists the files of a skill folder as (path, content) pairs; hashing them per §6 MUST produce exactly the recorded digest. Paths are given as they might be enumerated (including non-NFC forms); content is UTF-8 text (contentUtf8) or raw bytes (contentBase64), exactly one per file.",
+  "vectors": [
+    {
+      "name": "empty-folder",
+      "description": "Zero files hash to the SHA-256 of empty input (§6.5).",
+      "files": [],
+      "expected": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "name": "single-skill-md",
+      "description": "The common authoring case: a folder containing only SKILL.md.",
+      "files": [
+        {
+          "path": "SKILL.md",
+          "contentUtf8": "---\nname: hash-vector\ndescription: Golden vector fixture.\n---\n\n# Hash vector\n\nBody.\n"
+        }
+      ],
+      "expected": "2e7cb4e0d62309860ba0af58c176ea53c63827b371c4f61e55ffd58e89ff86d6"
+    },
+    {
+      "name": "nested-folders",
+      "description": "Multiple files including a nested path, joined with '/' on all platforms.",
+      "files": [
+        { "path": "a.txt", "contentUtf8": "alpha\n" },
+        { "path": "b.txt", "contentUtf8": "beta\n" },
+        { "path": "sub/c.txt", "contentUtf8": "gamma\n" }
+      ],
+      "expected": "838c47b6f4afe59206c87063181e49cf43f8f3a7d89f276dd208e5074bba8c22"
+    },
+    {
+      "name": "byte-order-not-locale-order",
+      "description": "UTF-8 byte order puts B.txt (0x42) before a.txt (0x61); locale-aware collation would reverse them. An implementation sorting with localeCompare or strcoll fails this vector.",
+      "files": [
+        { "path": "a.txt", "contentUtf8": "small\n" },
+        { "path": "B.txt", "contentUtf8": "big\n" }
+      ],
+      "expected": "51a197dc7e4e1b029ce47153ab466c36998f5807cc79473406c1a337ab8ee52d"
+    },
+    {
+      "name": "nfd-path-normalizes-to-nfc",
+      "description": "The path is given decomposed (e + U+0301), as APFS enumerates it; the digest is over the NFC form (U+00E9). An implementation that hashes paths without NFC normalization fails this vector.",
+      "files": [{ "path": "e\u0301.txt", "contentUtf8": "x\n" }],
+      "expected": "19b96d8c6ed9614410b688ec240fa70fbffc5b16cb540b6b003ed5bc6d40be23"
+    },
+    {
+      "name": "binary-content",
+      "description": "Content bytes go in raw — the framing NUL is a delimiter, not an escape, so embedded 0x00 and high bytes are hashed as stored.",
+      "files": [{ "path": "blob.bin", "contentBase64": "AAH/gAoA" }],
+      "expected": "b14660c775d3cd8f922fe1b011cd90df4005b74434ea76c764157788ace8eb2c"
+    },
+    {
+      "name": "utf8-byte-sort-not-utf16",
+      "description": "U+FFFD (ef bf bd) precedes U+1F600 (f0 9f 98 80) in UTF-8 bytes, but UTF-16 code-unit comparison (e.g. JavaScript's default sort) puts the surrogate pair first. An implementation sorting UTF-16 strings fails this vector.",
+      "files": [
+        { "path": "😀.txt", "contentUtf8": "g\n" },
+        { "path": "�.txt", "contentUtf8": "r\n" }
+      ],
+      "expected": "22015ef352189d0990a6a2e8231d87b1c8046949722b905aa8fee815328c80b1"
+    }
+  ]
+}

--- a/spec/draft/examples/hash/set-hash-vectors.json
+++ b/spec/draft/examples/hash/set-hash-vectors.json
@@ -1,0 +1,31 @@
+{
+  "algorithm": "skill-set/set-v1",
+  "description": "Golden vectors for the setHash rollup (spec §5). Each vector gives a member map of locator → computedHash; rolling it up per §5 MUST produce exactly the recorded digest. Locators are hashed as given — no normalization applies to them.",
+  "vectors": [
+    {
+      "name": "empty-set",
+      "description": "Zero members roll up to the SHA-256 of empty input.",
+      "members": {},
+      "expected": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "name": "two-members",
+      "description": "Members are concatenated in UTF-8 byte order of the locator, regardless of map insertion order.",
+      "members": {
+        "beta": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "alpha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "expected": "eec2eccf9a66a06dda6bd61db3414acca5d66d8edb0de8fe1dc63d2ff808f521"
+    },
+    {
+      "name": "unicode-and-escaped-locators",
+      "description": "Non-ASCII locators and characters JSON must escape sort by their UTF-8 bytes.",
+      "members": {
+        "a/ascii": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "z/caf\u00e9": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "m/back\\slash\"quote": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+      },
+      "expected": "f2c42cf5d0511bea3e431dce342b29f02951384f8f777935dc4335f266875d31"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Extracts the spec's hash recipes into a new zero-dependency package, **@skill-set/core**. 

Built so servers, registries, and non-CLI tooling can produce and verify skill-set hashes on any WebCrypto runtime (Node ≥20, Cloudflare Workers, Deno, Bun, browsers etc.)

### @skill-set/core (new, minor)

- bytes-in hash functions `specFolderHash`, `setHash`, `skillMarkdownFolderHash`, `compatFolderHash` canonical 
- framing functions `folderHashInput`, `setHashInput`, `compatFolderHashInput` for sync or streaming hashers spec
- algorithm identifiers `skill-set/folder-v1`, `skill-set/set-v1`
- typed lock-file shapes `SkillSetLock`, `SkillSetLockMember`

### @skill-set/cli (patch)
_No behavior change; outputs are byte-identical, cross-checked in tests_
- `hash.ts` now delegates canonical framing to core, keeping the filesystem adapter and a synchronous `node:crypto` digest. 

### Spec
- adds golden hash vectors `spec/draft/examples/hash/`, covering NFC normalization, UTF-8-byte sort order, and binary content.

## Testing

- `pnpm -r test`: core 24 passed, CLI 371 passed
- Smoke test of the built CLI: init/lock/verify/build flows, drift and frozen exit codes, JSON output purity - hashes verified as matching prior
- Core dist verified against all golden vectors 
- `nodenext` consumer typecheck and `npm pack --dry-run` surface check clean

## Notes

- Changesets included: core `minor` (publishes 0.1.0), CLI `patch`.
