### PR TITLE
ADD: Shorthand add sources for the reference directory

### DIFF
--- a/.changeset/shorthand-add-sources.md
+++ b/.changeset/shorthand-add-sources.md
@@ -1,0 +1,5 @@
+---
+'@skill-set/cli': minor
+---
+
+`add` accepts shorthand sources, expanded to the full manifest URL before anything is fetched: an https URL whose last path segment is a bare set name gains `/<segment>.skill-set.json` (any host), and a bare set name with no matching local file resolves against the skill-sets.md directory — `skill-set add hash-demo` fetches `https://skill-sets.md/sets/hash-demo/hash-demo.skill-set.json`. Both forms still carry a `#sha256=` pin and fetch the sidecar lock when published. Full URLs, local paths, and existing local files behave exactly as before.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ A set is shared as a URL to its manifest. This one is real — it installs a wor
 npx @skill-set/cli add https://skill-sets.md/sets/hash-demo/hash-demo.skill-set.json
 ```
 
+Directory sets can resolve from the slug, e.g., `npx @skill-set/cli add hash-demo` fetches the same manifest. Omitting `.skill-set.json` expands the same way, on any host.
+
 ### Author your own
 
 ```sh
@@ -59,7 +61,7 @@ Publish the manifest and lock anywhere HTTPS-reachable (`share` exports both), a
 | Command | What it does |
 | --- | --- |
 | `init <set> [locators...]` | Scaffold a new set manifest |
-| `add <url\|path> [--hash]` | Fetch a shared set manifest, then install it |
+| `add <url\|path\|name> [--hash]` | Fetch a shared set manifest, then install it |
 | `install <set>` | Install members, skipping ones the lock already satisfies |
 | `build [<set>] [--lock]` | Regenerate SKILL-SET.md files and the skill-sets.json index |
 | `lock <set>` | Record each member's installed content in a set-lock |

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -2,7 +2,7 @@ import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync
 import { join } from 'node:path'
 import { ErrorCodes, SkillSetError, type Result } from '../errors.ts'
 import { createSetLock, LOCK_SUFFIX, parseSetLock, serializeSetLock, type SetLock } from '../lock.ts'
-import { MANIFEST_SUFFIX, parseManifest, type Manifest } from '../manifest.ts'
+import { MANIFEST_SUFFIX, NAME_PATTERN, parseManifest, type Manifest } from '../manifest.ts'
 import { loadLockIfPresent, SETS_DIR, setPaths, writeIndex, writeSetPage } from '../project.ts'
 import { parseLocator, reservedMembers, reservedNameError, SKILLS_DIR } from '../resolver.ts'
 import { localContentMismatches, removeStagingProject, reportLocalDrift, stageManifestMembers } from '../staging.ts'
@@ -10,7 +10,7 @@ import { installSet } from './install.ts'
 import { lockSet } from './lock.ts'
 import { formatInvocation, plural, splitFlags, usageError, type CommandContext, type CommandResult } from './context.ts'
 
-export const ADD_USAGE = 'skill-set add <url|path> [--hash sha256:<hex>]'
+export const ADD_USAGE = 'skill-set add <url|path|name> [--hash sha256:<hex>]'
 
 /** Spec §3 fetch bounds: at most five redirects, at most 1 MiB of manifest. */
 const MAX_REDIRECTS = 5
@@ -61,6 +61,39 @@ function isAllowedHost(host: string): boolean {
   return ALLOWED_HOSTS.includes(host)
 }
 
+/** Where bare set names resolve: the reference directory's sets root. */
+export const DEFAULT_DIRECTORY = 'https://skill-sets.md/sets'
+
+/**
+ * Expands shorthand sources to a full manifest URL, before the #sha256= fragment is split off.
+ * Spec §2 ties `name` to the manifest filename, so a conforming manifest URL always ends in
+ * `.skill-set.json`: an https URL whose last path segment is a bare set name is shorthand for
+ * `<url>/<segment>.skill-set.json` (any host), and a bare name with no matching local file is
+ * shorthand for the same path under the default directory. Everything else passes through.
+ */
+export function expandAddSource(raw: string, exists: (path: string) => boolean = existsSync): string {
+  const at = raw.indexOf('#')
+  const base = at === -1 ? raw : raw.slice(0, at)
+  const fragment = at === -1 ? '' : raw.slice(at)
+  if (/^https:\/\//i.test(raw)) {
+    let url: URL
+    try {
+      url = new URL(base)
+    } catch {
+      return raw
+    }
+    if (url.pathname.endsWith(MANIFEST_SUFFIX)) return raw
+    const segments = url.pathname.split('/').filter((s) => s !== '')
+    const slug = segments[segments.length - 1]
+    if (slug === undefined || !NAME_PATTERN.test(slug)) return raw
+    return `${url.origin}/${segments.join('/')}/${slug}${MANIFEST_SUFFIX}${url.search}${fragment}`
+  }
+  if (/^http:\/\//i.test(raw)) return raw
+  // A local file of the same name wins, keeping existing path behaviour byte-for-byte.
+  if (!NAME_PATTERN.test(base) || exists(raw) || exists(base)) return raw
+  return `${DEFAULT_DIRECTORY}/${base}/${base}${MANIFEST_SUFFIX}${fragment}`
+}
+
 /** Host of an https URL, or undefined for non-https / unparseable sources (local paths). */
 function httpsHost(source: string): string | undefined {
   if (!/^https:\/\//i.test(source)) return undefined
@@ -77,9 +110,13 @@ export async function cmdAdd(args: string[], ctx: CommandContext): Promise<Comma
   const [rawSource, ...extra] = split.data.positionals
   if (rawSource === undefined || extra.length > 0) return usageError('add takes exactly one manifest URL or path', ADD_USAGE)
 
+  // Shorthand expansion runs first so a bare name or directory URL can still carry a #sha256=
+  // fragment; the "Adding skill-set from" line below then shows the real fetch target.
+  const expanded = expandAddSource(rawSource)
+
   // The pinned hash comes from --hash and/or a #sha256= URL fragment; the fragment is a
   // trust anchor, not part of the location, so it is stripped before any fetch or record.
-  const pin = resolvePinnedHash(rawSource, split.data.values.get('--hash'))
+  const pin = resolvePinnedHash(expanded, split.data.values.get('--hash'))
   if (!pin.ok) return pin
   const { source, hash } = pin.data
 

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -23,7 +23,7 @@ interface CommandEntry {
 
 const COMMANDS: Record<string, CommandEntry> = {
   init: { usage: 'init <set> [locators...]', describe: 'Scaffold a new set manifest', handler: cmdInit },
-  add: { usage: 'add <url|path> [--hash]', describe: 'Fetch a shared set manifest, then install it', handler: cmdAdd },
+  add: { usage: 'add <url|path|name> [--hash]', describe: 'Fetch a shared set manifest, then install it', handler: cmdAdd },
   install: { usage: 'install <set>', describe: 'Install members, skipping ones the lock already satisfies', handler: cmdInstall },
   build: { usage: 'build [<set>] [--lock]', describe: 'Regenerate SKILL-SET.md files and the skill-sets.json index', handler: cmdBuild },
   lock: { usage: 'lock <set>', describe: "Record each member's installed content in a set-lock", handler: cmdLock },

--- a/packages/cli/test/cli-commands.test.ts
+++ b/packages/cli/test/cli-commands.test.ts
@@ -3,6 +3,7 @@ import { appendFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSyn
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterAll, describe, expect, it } from 'vitest'
+import { DEFAULT_DIRECTORY, expandAddSource } from '../src/commands/add.ts'
 import { INDEX_FILENAME } from '../src/generate.ts'
 import { setHash } from '../src/hash.ts'
 import { createSetLock, parseSetLock, serializeSetLock } from '../src/lock.ts'
@@ -628,6 +629,100 @@ describe('add — trusted-host allowlist', () => {
     expect(code).toBe(0)
     expect(fetched).toEqual([unknownUrl, 'https://unknown-origin.invalid/unknown-set.skill-set.lock.json'])
     expect(existsSync(join(cwd, SETS_DIR, 'unknown-set'))).toBe(true)
+  })
+})
+
+describe('add — shorthand sources', () => {
+  const body = (name: string) =>
+    `${JSON.stringify({ name, version: '1.0.0', description: 'A set.', skills: ['hcjmartin/gamma-repo@gamma'] }, null, 2)}\n`
+  const kitUrl = `${DEFAULT_DIRECTORY}/kit/kit.skill-set.json`
+
+  function tracked(map: Record<string, string>): { fetcher: RunOverrides['fetcher']; fetched: string[] } {
+    const fetched: string[] = []
+    const fetcher: RunOverrides['fetcher'] = async (url: string) => {
+      fetched.push(url)
+      return url in map
+        ? { ok: true as const, data: map[url]! }
+        : { ok: false as const, error: new Error('unexpected url') as never }
+    }
+    return { fetcher, fetched }
+  }
+
+  it('a bare name resolves to the default directory and records the expanded source', async () => {
+    const cwd = project()
+    const fake = fakeSkills(cwd)
+    const { fetcher, fetched } = tracked({ [kitUrl]: body('kit') })
+    const { code, out } = await cli(cwd, fake, ['add', 'kit', '--yes'], { fetcher })
+    expect(code).toBe(0)
+    expect(out).toContain(`Adding skill-set from ${kitUrl}...`)
+    expect(fetched[0]).toBe(kitUrl)
+    const index = JSON.parse(readFileSync(join(cwd, SETS_DIR, INDEX_FILENAME), 'utf8')) as {
+      sets: Record<string, { source?: string }>
+    }
+    expect(index.sets['kit']!.source).toBe(kitUrl)
+  })
+
+  it('a bare name carries a #sha256= fragment through to the pin', async () => {
+    const cwd = project()
+    const fake = fakeSkills(cwd)
+    const { fetcher, fetched } = tracked({ [kitUrl]: body('kit') })
+    // A wrong pin proves the fragment reached verification; the fetch stays fragment-free.
+    const { code, err } = await cli(cwd, fake, ['add', `kit#sha256=${'b'.repeat(64)}`, '--yes'], { fetcher })
+    expect(code).toBe(3)
+    expect(err).toContain('did not match the verification hash')
+    expect(fetched[0]).toBe(kitUrl)
+  })
+
+  it.each([
+    [`${DEFAULT_DIRECTORY}/kit`],
+    [`${DEFAULT_DIRECTORY}/kit/`],
+  ])('a directory URL %s expands to the manifest inside it', async (short) => {
+    const cwd = project()
+    const fake = fakeSkills(cwd)
+    const { fetcher, fetched } = tracked({ [kitUrl]: body('kit') })
+    const { code } = await cli(cwd, fake, ['add', short, '--yes'], { fetcher })
+    expect(code).toBe(0)
+    expect(fetched[0]).toBe(kitUrl)
+  })
+
+  it('an unknown-host directory URL expands but still prompts for the host', async () => {
+    const cwd = project()
+    const fake = fakeSkills(cwd)
+    const full = 'https://unknown-origin.invalid/sets/kit/kit.skill-set.json'
+    const { fetcher, fetched } = tracked({ [full]: body('kit') })
+    const { code } = await cli(cwd, fake, ['add', 'https://unknown-origin.invalid/sets/kit'], {
+      fetcher,
+      confirmAnswers: [true, true],
+    })
+    expect(code).toBe(0)
+    expect(fetched[0]).toBe(full)
+  })
+
+  it('expandAddSource leaves non-shorthand sources untouched', () => {
+    const never = () => false
+    // Already a manifest URL, with and without a fragment.
+    expect(expandAddSource(`${kitUrl}#sha256=${'a'.repeat(64)}`, never)).toBe(`${kitUrl}#sha256=${'a'.repeat(64)}`)
+    expect(expandAddSource(kitUrl, never)).toBe(kitUrl)
+    // Last segment is not a bare set name (dots, uppercase, or nothing at all).
+    expect(expandAddSource('https://skill-sets.md/sets/kit.skill-set.lock.json', never)).toBe('https://skill-sets.md/sets/kit.skill-set.lock.json')
+    expect(expandAddSource('https://skill-sets.md/sets/Kit', never)).toBe('https://skill-sets.md/sets/Kit')
+    expect(expandAddSource('https://skill-sets.md', never)).toBe('https://skill-sets.md')
+    // Paths and http URLs pass through for the existing flows to accept or reject.
+    expect(expandAddSource('./kit', never)).toBe('./kit')
+    expect(expandAddSource('http://example.test/kit', never)).toBe('http://example.test/kit')
+  })
+
+  it('expandAddSource expands directory URLs and bare names, keeping the fragment', () => {
+    const never = () => false
+    expect(expandAddSource(`${DEFAULT_DIRECTORY}/kit#sha256=${'a'.repeat(64)}`, never)).toBe(`${kitUrl}#sha256=${'a'.repeat(64)}`)
+    expect(expandAddSource('kit', never)).toBe(kitUrl)
+    expect(expandAddSource(`kit#sha256=${'a'.repeat(64)}`, never)).toBe(`${kitUrl}#sha256=${'a'.repeat(64)}`)
+  })
+
+  it('expandAddSource prefers an existing local file over the directory', () => {
+    const exists = (path: string) => path === 'kit'
+    expect(expandAddSource('kit', exists)).toBe('kit')
+    expect(expandAddSource('other', exists)).toBe(`${DEFAULT_DIRECTORY}/other/other.skill-set.json`)
   })
 })
 

--- a/packages/site/src/pages/cli.md
+++ b/packages/site/src/pages/cli.md
@@ -20,7 +20,7 @@ skill-set/<version> (wraps skills@1.5.14, pinned)
 | Command | Usage | Does |
 | --- | --- | --- |
 | [`init`](#init) | `init <set> <locator> [locators...]` | Scaffold a new set manifest |
-| [`add`](#add) | `add <url\|path>` | Fetch a shared set manifest, then install it |
+| [`add`](#add) | `add <url\|path\|name>` | Fetch a shared set manifest, then install it |
 | [`install`](#install) | `install <set>` | Install members, skipping ones the lock already satisfies |
 | [`build`](#build) | `build [<set>] [--lock]` | Regenerate SKILL-SET.md files and the skill-sets.json index |
 | [`lock`](#lock) | `lock <set>` | Record each member's installed content in a set-lock |
@@ -40,10 +40,12 @@ Scaffolds `.agents/skills/skill-sets/<set>/<set>.skill-set.json` at version `0.1
 ### add
 
 ```shellscript
-skill-set add <url|path>
+skill-set add <url|path|name>
 ```
 
 Acquires a shared set: fetches the manifest (HTTPS only; at most 5 redirects; 1 MiB response cap) or reads a local path, validates it against the schema and rules, prints the set summary with every member and its source, then asks for confirmation before writing anything. The fetched bytes are written verbatim as `<name>.skill-set.json` — the filename comes from the manifest's `name` — and the normal install flow runs.
+
+Shorthand sources expand to the full manifest URL before anything is fetched, and the expanded URL is printed first. An `https://` URL whose last path segment is a bare set name will auto-resolve to `/<segment>.skill-set.json`. A bare set name with no matching local file resolves against the [skill-sets.md](https://skill-sets.md) reference directory: `skill-set add hash-demo` fetches `https://skill-sets.md/sets/hash-demo/hash-demo.skill-set.json`. Both forms still accept a `#sha256=` fragment and resolve locks if available.
 
 Hosts other than recognised skill-set providers prompt for confirmation before any bytes are fetched, and redirects may not hop to a new host. An existing set with the same name is an error, never a silent overwrite.
 

--- a/spec/draft/README.md
+++ b/spec/draft/README.md
@@ -59,6 +59,8 @@ A skill-set is shareable as **a URL to its manifest** — any HTTPS location ser
 3. Writing it into the project as `<name>.skill-set.json`, with the filename derived from the manifest's `name`. If a set file of that name already exists, the implementation MUST fail rather than silently overwrite.
 4. Proceeding with normal installation, presenting the member/source summary first.
 
+**Shorthand manifest URLs** (non-normative). The name ↔ filename rule (§2) means a conforming manifest URL always ends in `.skill-set.json`. Implementations MAY therefore treat an HTTPS URL whose final path segment is a bare set name as shorthand, expanding it to `<url>/<segment>.skill-set.json` before fetching (and before stripping any `#sha256=` fragment, which shorthand shares may carry). Resolving a bare set name against a default host is implementation policy, outside this specification.
+
 ### Receipt-time verification
 
 The manifest carries locators, never hashes (§1), so acquisition alone is trust-on-first-use: the first install resolves whatever the locators currently point at. Two optional, composable mechanisms let a recipient verify received content against the author's resolved reality (§5) before it is used:


### PR DESCRIPTION
## What

`skill-set add` now accepts shorthand sources, expanded deterministically to the full manifest URL before anything is fetched:

- **Directory URL** (any host): an `https://` URL whose last path segment is a bare set name gains `/<segment>.skill-set.json` — `add https://skill-sets.md/sets/hash-demo` fetches the manifest inside that directory. Trailing slashes work.
- **Bare set name**: with no matching local file, resolves against the skill-sets.md directory — `skill-set add hash-demo` fetches `https://skill-sets.md/sets/hash-demo/hash-demo.skill-set.json`. A local file of the same name always wins.
- Both forms still retain any `#sha256=` pin (expansion runs before the fragment is split off) and fetch the sidecar lock when published.

## Why

Short links were previously unsupported and a bare name errored as a missing local path. Expansion is deterministic rather than try-then-fallback.

## Changes

- `expandAddSource` in `commands/add.ts`, wired ahead of `resolvePinnedHash`; the existing "Adding skill-set from …" line prints the real fetch target before any bytes move. Full URLs, local paths, and `http://` pass through untouched.
- Usage strings > `add <url|path|name>`; README, CLI reference page, and a non-normative "Shorthand manifest URLs" note in spec §3 (default-host resolution stays implementation policy).
- New "add — shorthand sources" test suite (8 tests: bare name, fragment pinning, both directory-URL shapes, unknown-host prompting, pass-through edges, local-file precedence). Verified live against skill-sets.md with dry-runs of all three forms.
- Changeset: minor for `@skill-set/cli`.