### PR TITLE
CHORE: Core copy edits stranded on add/core-package

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -2,7 +2,7 @@
 
 Runtime-agnostic primitives for the [skill-set format](https://github.com/hcjmartin/skill-set/blob/main/spec/draft/README.md): content hashes, algorithm identifiers, and lock-file types.
 
-Built for servers, edge runtimes and registries outside of [`@skill-set/cli`](https://www.npmjs.com/package/@skill-set/cli), so you don't have to port. Inputs are `(path, bytes)` pairs rather than directories, and digests use WebCrypto, so the same code runs on Node ≥20, Cloudflare Workers, Deno, Bun, and browsers etc. 
+Built for servers, edge runtimes and registries outside of [`@skill-set/cli`](https://www.npmjs.com/package/@skill-set/cli), so you don't have to port. Inputs are `(path, bytes)` pairs rather than directories, and digests use WebCrypto, so the same code runs on Node ≥20, Cloudflare Workers, Deno, Bun, and browsers.
 
 Zero dependencies.
 
@@ -48,7 +48,7 @@ Hashes are byte-identical to the reference CLI's and to any conforming implement
 | `skillMarkdownFolderHash(content)` | Folder hash of a lone `SKILL.md` — the common authoring case. |
 | `setHash(members)` | Set-lock rollup (spec §5) over `{ locator: computedHash }`. |
 | `folderHashInput(files)` / `setHashInput(members)` | The exact canonical byte sequences the recipes digest, for synchronous or streaming hashers (the CLI feeds these to `node:crypto`). |
-| `FOLDER_HASH_ALGORITHM` / `SET_HASH_ALGORITHM` | Spec lgorithm identifiers, for storing or transmitting digests with provenance. |
+| `FOLDER_HASH_ALGORITHM` / `SET_HASH_ALGORITHM` | Spec algorithm identifiers, for storing or transmitting digests with provenance. |
 | `SkillSetLock` / `SkillSetLockMember` | Typed shape of `<name>.skill-set.lock.json` (types only — schema validation stays the reader's responsibility). |
 | `compatFolderHash(files)` / `compatFolderHashInput(files)` | **Not a spec algorithm.** Byte-compatible with `vercel-labs/skills` `computeSkillFolderHash` (v1.5.x), for `skills-lock.json` interop only; locale-sensitive by upstream design. |
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,8 +1,10 @@
 # @skill-set/core
 
-Runtime-agnostic primitives for the [skill-set format](https://github.com/hcjmartin/skill-set/blob/main/spec/draft/README.md): the spec's content hashes, their algorithm identifiers, and lock-file types.
+Runtime-agnostic primitives for the [skill-set format](https://github.com/hcjmartin/skill-set/blob/main/spec/draft/README.md): content hashes, algorithm identifiers, and lock-file types.
 
-Built for implementations the [`@skill-set/cli`](https://www.npmjs.com/package/@skill-set/cli) can't serve — servers, edge runtimes, registries — so they don't have to port the spec recipes by hand. Inputs are `(path, bytes)` pairs rather than directories, and digests use WebCrypto, so the same code runs on Node ≥20, Cloudflare Workers, Deno, Bun, and browsers. Zero dependencies.
+Built for servers, edge runtimes and registries outside of [`@skill-set/cli`](https://www.npmjs.com/package/@skill-set/cli), so you don't have to port. Inputs are `(path, bytes)` pairs rather than directories, and digests use WebCrypto, so the same code runs on Node ≥20, Cloudflare Workers, Deno, Bun, and browsers etc. 
+
+Zero dependencies.
 
 ```sh
 npm install @skill-set/core
@@ -29,14 +31,14 @@ const computedHash = await specFolderHash([
 // The common single-file case.
 const hash = await skillMarkdownFolderHash(markdown)
 
-// Set-lock rollup (spec §5) — directly comparable to a `.skill-set.lock.json`.
+// Set-lock rollup — directly comparable to a `.skill-set.lock.json`.
 const lock: SkillSetLock = JSON.parse(lockJson)
 const verified = (await setHash(
   Object.fromEntries(Object.entries(lock.skills).map(([loc, m]) => [loc, m.computedHash])),
 )) === lock.setHash
 ```
 
-Hashes are byte-identical to the reference CLI's and to any conforming implementation — the recipes are locale-independent by construction (NFC paths, UTF-8-byte-order sort, NUL framing), and this package's test suite is pinned to the spec's [golden vectors](https://github.com/hcjmartin/skill-set/tree/main/spec/draft/examples/hash).
+Hashes are byte-identical to the reference CLI's and to any conforming implementation. Recipes are locale-independent by construction (NFC paths, UTF-8-byte-order sort, NUL framing), and this package's test suite is pinned to the spec's [golden vectors](https://github.com/hcjmartin/skill-set/tree/main/spec/draft/examples/hash).
 
 ## API
 
@@ -46,7 +48,7 @@ Hashes are byte-identical to the reference CLI's and to any conforming implement
 | `skillMarkdownFolderHash(content)` | Folder hash of a lone `SKILL.md` — the common authoring case. |
 | `setHash(members)` | Set-lock rollup (spec §5) over `{ locator: computedHash }`. |
 | `folderHashInput(files)` / `setHashInput(members)` | The exact canonical byte sequences the recipes digest, for synchronous or streaming hashers (the CLI feeds these to `node:crypto`). |
-| `FOLDER_HASH_ALGORITHM` / `SET_HASH_ALGORITHM` | The spec's algorithm identifiers, for storing or transmitting digests with provenance. |
+| `FOLDER_HASH_ALGORITHM` / `SET_HASH_ALGORITHM` | Spec lgorithm identifiers, for storing or transmitting digests with provenance. |
 | `SkillSetLock` / `SkillSetLockMember` | Typed shape of `<name>.skill-set.lock.json` (types only — schema validation stays the reader's responsibility). |
 | `compatFolderHash(files)` / `compatFolderHashInput(files)` | **Not a spec algorithm.** Byte-compatible with `vercel-labs/skills` `computeSkillFolderHash` (v1.5.x), for `skills-lock.json` interop only; locale-sensitive by upstream design. |
 

--- a/packages/core/src/hash.ts
+++ b/packages/core/src/hash.ts
@@ -3,8 +3,8 @@
  *
  * Runtime-agnostic by construction — inputs are (path, bytes) pairs rather than
  * a directory, and digests use WebCrypto — so the same code runs on Node ≥20,
- * and browsers. Enumerating a real folder into pairs is the caller's 
- * platform-specific part (the reference CLI's filesystem adapter skips 
+ * and browsers. Enumerating a real folder into pairs is the caller's
+ * platform-specific part (the reference CLI's filesystem adapter skips
  * `.git`/`node_modules` dirs and symlinks per §6.1).
  *
  * The `*Input` functions expose the exact canonical byte sequence each recipe

--- a/packages/core/src/hash.ts
+++ b/packages/core/src/hash.ts
@@ -3,9 +3,9 @@
  *
  * Runtime-agnostic by construction — inputs are (path, bytes) pairs rather than
  * a directory, and digests use WebCrypto — so the same code runs on Node ≥20,
- * Cloudflare Workers, Deno, Bun, and browsers. Enumerating a real folder into
- * pairs is the caller's platform-specific part (the reference CLI's filesystem
- * adapter skips `.git`/`node_modules` dirs and symlinks per §6.1).
+ * and browsers. Enumerating a real folder into pairs is the caller's 
+ * platform-specific part (the reference CLI's filesystem adapter skips 
+ * `.git`/`node_modules` dirs and symlinks per §6.1).
  *
  * The `*Input` functions expose the exact canonical byte sequence each recipe
  * digests, for callers that need a synchronous or streaming hasher (the CLI


### PR DESCRIPTION
Cherry-picks the two copy-only commits that landed on `add/core-package` after PR #33 was squash-merged, so they never reached main:

- `CHORE: Update README for brevity` — tightens the `@skill-set/core` README intro and trims spec-section parentheticals.
- `CHORE: Remove reference to platforms in hash.ts` — doc-comment only; the full platform list stays in the README.

Plus a small fixup: "Spec lgorithm" → "Spec algorithm", removes a stray "etc." at the end of the platform list, and strips trailing whitespace the edits introduced.

Doc/comment-only, so no changeset. Once merged, `add/core-package` can be deleted — everything else on it was released via #33/#34.