### PR TITLE
MOD: Plain --version output

### DIFF
--- a/.changeset/plain-version-output.md
+++ b/.changeset/plain-version-output.md
@@ -1,0 +1,5 @@
+---
+'@skill-set/cli': patch
+---
+
+`--version` prints just `skill-set/<version>`; the `(wraps skills@<pin>, pinned)` suffix is gone. The upstream pin still shows where it acts — every spawned invocation prints as `npx skills@<pin> …`.

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -1,6 +1,6 @@
 import pkg from '../package.json' with { type: 'json' }
 import { ErrorCodes, SkillSetError, type Result, type SkillSetErrorCode } from './errors.ts'
-import { SKILLS_PIN, type CommandRunner } from './resolver.ts'
+import { type CommandRunner } from './resolver.ts'
 import { createUi, type Writer } from './ui.ts'
 import { cmdAdd } from './commands/add.ts'
 import { cmdBuild } from './commands/build.ts'
@@ -50,7 +50,7 @@ Flags:
   --dry-run             Print what would run or be written; change nothing, spawn nothing
   --hash sha256:<hex>   For add: keep the set only if its content matches this set hash
   --help, -h            Show this help
-  --version, -v         Show the skill-set version and the pinned skills version
+  --version, -v         Show the skill-set version
 
 Args after "--" pass through to the skills CLI verbatim.
   e.g. "skill-set install demo -- --agent claude-code cursor" installs to those agents only.
@@ -91,7 +91,7 @@ export async function run(argv: readonly string[], overrides: RunOverrides = {})
     return 0
   }
   if (ours.includes('--version') || ours.includes('-v')) {
-    stdout.write(`skill-set/${VERSION} (wraps skills@${SKILLS_PIN}, pinned)\n`)
+    stdout.write(`skill-set/${VERSION}\n`)
     return 0
   }
 

--- a/packages/cli/test/package-surface.test.ts
+++ b/packages/cli/test/package-surface.test.ts
@@ -3,7 +3,6 @@ import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import pkg from '../package.json' with { type: 'json' }
 import { SUPPORTED_SCHEMA_VERSIONS } from '../src/manifest.ts'
-import { SKILLS_PIN } from '../src/resolver.ts'
 import { VERSION } from '../src/run.ts'
 import { runCommand } from '../src/spawn.ts'
 
@@ -54,15 +53,14 @@ describe('built bin wiring', () => {
     expect(shim).toContain("import('../dist/cli.mjs')")
   })
 
-  it('the built bin runs and reports both versions', async () => {
+  it('the built bin runs and reports the version', async () => {
     // Requires a prior build (`check` and CI both build before testing).
     expect(existsSync(join(pkgDir, 'dist', 'cli.mjs'))).toBe(true)
     const result = await runCommand(process.execPath, [binPath, '--version'], { capture: true })
     expect(result.ok).toBe(true)
     if (result.ok) {
       expect(result.data.exitCode).toBe(0)
-      expect(result.data.stdout).toContain(`skill-set/${VERSION}`)
-      expect(result.data.stdout).toContain(`skills@${SKILLS_PIN}`)
+      expect(result.data.stdout).toBe(`skill-set/${VERSION}\n`)
     }
   })
 

--- a/packages/cli/test/run.test.ts
+++ b/packages/cli/test/run.test.ts
@@ -43,11 +43,10 @@ describe('run — dispatch and meta-flags', () => {
     expect(err).toBe('')
   })
 
-  it('reports both our version and the upstream pin with --version', async () => {
+  it('prints exactly the version with --version', async () => {
     const { code, out } = await cli(['--version'])
     expect(code).toBe(0)
-    expect(out).toContain(`skill-set/${VERSION}`)
-    expect(out).toContain('skills@1.5.14')
+    expect(out).toBe(`skill-set/${VERSION}\n`)
   })
 
   it('intercepts --version after a verb before any dispatch', async () => {

--- a/packages/site/src/pages/cli.md
+++ b/packages/site/src/pages/cli.md
@@ -9,11 +9,7 @@ lede: The CLI ships as @skill-set/cli with a single bin, skill-set. Run it witho
 npx @skill-set/cli <command> [args] [flags] [-- <args for the skills CLI>]
 ```
 
-Resolution and installation of individual skills are delegated to the upstream [skills CLI](https://skills.sh), pinned to `skills@1.5.14`. `skill-set --version` prints both versions:
-
-```
-skill-set/<version> (wraps skills@1.5.14, pinned)
-```
+Resolution and installation of individual skills are delegated to the upstream [skills CLI](https://skills.sh), pinned to `skills@1.5.14` — every spawned invocation names the pin, e.g. `npx skills@1.5.14 add <locator>`.
 
 ## Commands
 


### PR DESCRIPTION
Drops the skills.sh cli tool reference in `--version`. The pin still surfaces on every spawned upstream invocation. Patch changeset for `@skill-set/cli`.